### PR TITLE
docs: adiciona capacidade planejada da equipe

### DIFF
--- a/docs/capacidade.md
+++ b/docs/capacidade.md
@@ -18,8 +18,8 @@ Próximo marco: Entrega 3 - 9/4/2026
  
 ### Nicolas Pitz - Engenheiro de Qualidade
 
-- Disponibilidade: 
-- Restrições: 
+- Disponibilidade: horas de aulas dedicadas ao projeto + tempo livre em finais de semana
+- Restrições: imprevistos em dias de aulas e finais de semana
 
 ### Gabriela Riedel - Scrum Master
 

--- a/docs/capacidade.md
+++ b/docs/capacidade.md
@@ -1,0 +1,37 @@
+# Capacidade da equipe
+
+Integrantes ativos: 4
+
+Próximo marco: Entrega 3 - 9/4/2026
+
+## Integrantes
+
+### Renato Freitas - Arquiteto de Software
+
+- Disponibilidade: horas de aula dedicadas ao projeto + 2h semanais de estudo
+- Restrições: tempo de aula dedicado ao projeto não é previsível
+
+### Nícolas Arthur - DevOps/Infra
+
+- Disponibilidade: 
+- Restrições:
+ 
+### Nicolas Pitz - Engenheiro de Qualidade
+
+- Disponibilidade: 
+- Restrições: 
+
+### Gabriela Riedel - Scrum Master
+
+- Disponibilidade: 
+- Restrições: 
+
+## Restrições gerais
+
+- Todos os membros trabalham e são estudantes, dividindo tempo com emprego e outras disciplinas
+- Disponibilidade de aula para o projeto varia conforme o calendário da disciplina
+
+## Fatores que podem afetar produtividade
+
+- Período de provas de outras matérias
+- Curva de aprendizado com a stack escolhida (Go, frontend ainda em definição)

--- a/docs/capacidade.md
+++ b/docs/capacidade.md
@@ -23,8 +23,8 @@ Próximo marco: Entrega 3 - 9/4/2026
 
 ### Gabriela Riedel - Scrum Master
 
-- Disponibilidade: 
-- Restrições: 
+- Disponibilidade: horas de aulas dedicadas ao projeto + 1h a 2h semanais
+- Restrições: rotina diária imprevisível
 
 ## Restrições gerais
 

--- a/docs/capacidade.md
+++ b/docs/capacidade.md
@@ -13,8 +13,8 @@ Próximo marco: Entrega 3 - 9/4/2026
 
 ### Nícolas Arthur - DevOps/Infra
 
-- Disponibilidade: 
-- Restrições:
+- Disponibilidade: horas de aula dedicadas ao projeto + finais de semana
+- Restrições: imprevistos de finais de semana
  
 ### Nicolas Pitz - Engenheiro de Qualidade
 

--- a/docs/capacidade.md
+++ b/docs/capacidade.md
@@ -15,7 +15,7 @@ Próximo marco: Entrega 3 - 9/4/2026
 
 - Disponibilidade: horas de aula dedicadas ao projeto + finais de semana
 - Restrições: imprevistos de finais de semana
- 
+
 ### Nicolas Pitz - Engenheiro de Qualidade
 
 - Disponibilidade: horas de aulas dedicadas ao projeto + tempo livre em finais de semana


### PR DESCRIPTION
## O que mudou

- Criação do arquivo docs/capacidade.md com capacidade individual, restrições gerais e fatores de produtividade

## Por quê

- Entrega 3 exige registro da capacidade planejada da equipe até o próximo marco

## Como testar

- Verificar se o arquivo docs/capacidade.md existe e contém a estrutura para cada membro

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [ ] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)

- [Manutenção] Disponibilidade de 3 membros ainda precisa ser preenchida (issue #26)
- [Risco] Capacidade pode mudar ao longo do semestre e precisa ser revisada a cada marco
- [Manutenção] Fatores de produtividade foram definidos de forma genérica, podem ser refinados