### PR TITLE
docs: consolidação do fluxo de trabalho no repositório

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Excesso de informação descentralizada e dados desestruturados sem métodos de 
 ## DoD
 - Cobertura de testes unitários mínima de 80%
 - Feature revisada e aprovada por pares
+
+## Fluxo de trabalho
+
+O fluxo de trabalho do projeto está documentado em [fluxo de trabalho](docs/fluxo-de-trabalho.md)

--- a/docs/fluxo-de-trabalho.md
+++ b/docs/fluxo-de-trabalho.md
@@ -50,9 +50,3 @@ Todo PR exige no mínimo 1 aprovação de um par antes de ser mergeado. O autor 
 ## Template de PR com checklist mínimo
 
 Todo PR aberto no repositório utiliza o template em [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md)
-
-## Referências
-
-- [git-flow.md](./git-flow.md) estratégia de branches e fluxo detalhado
-- [README.md](../README.md) governança e Definition of Done
-- [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) template de pull request

--- a/docs/fluxo-de-trabalho.md
+++ b/docs/fluxo-de-trabalho.md
@@ -1,0 +1,58 @@
+# Fluxo de Trabalho
+
+Este documento consolida as regras de colaboração no repositório do Markupp. Ele reúne, em um só lugar, como o código entra no projeto: branches, pull requests, revisão e integração na `main`.
+
+## Uso obrigatório de branches
+
+Todo desenvolvimento acontece em branches criadas a partir da `dev`. Não é permitido trabalhar diretamente na `main`.
+
+Commits direto na `dev` devem ser justificados, de tamanho atômico e pontuais, qualquer trabalho que exija mais de um commit deve seguir em uma branch separada.
+
+- `main`: branch de produção, só recebe merges da `dev`
+- `dev`: branch de integração, onde as features convergem antes de ir para produção
+- Branches de trabalho: criadas a partir da `dev`, seguindo o padrão [conventional branches](https://conventional-branch.github.io/).
+
+Detalhes em [git-flow.md](./git-flow.md).
+
+## Integração de mudanças via pull request
+
+Nenhum código entra na `main` sem passar por pull request. Commits seguem o padrão conventional commits em português.
+
+Ciclo de vida de uma mudança:
+
+1. Criar branch de trabalho a partir da `dev`
+2. Desenvolver e commitar na branch
+3. Abrir PR da branch de trabalho para a `dev`
+4. Obter revisão e aprovação de um par
+5. Mergear na `dev`
+6. Quando a `dev` estiver estável, abrir PR da `dev` para a `main`
+
+## Quem revisa e aprova PRs
+
+| Ação | Quem pode |
+|------|-----------|
+| Abrir PR | Qualquer integrante da equipe |
+| Revisar e aprovar PR | Qualquer par (integrante diferente do autor) |
+| Mergear na `main` | Somente via PR aprovado vindo da `dev` |
+
+Ver seção Governança no [README.md](../README.md).
+
+## Aprovação mínima antes da integração
+
+Todo PR exige no mínimo 1 aprovação de um par antes de ser mergeado. O autor do PR não pode aprovar o próprio PR.
+
+## Política de push direto na branch principal
+
+- Não se deve fazer push direto para `main`.
+- Não se deve abrir PR de branches de trabalho diretamente para a `main`.
+- A `main` só aceita merge vindo da `dev` via PR aprovado por um par.
+
+## Template de PR com checklist mínimo
+
+Todo PR aberto no repositório utiliza o template em [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md)
+
+## Referências
+
+- [git-flow.md](./git-flow.md) estratégia de branches e fluxo detalhado
+- [README.md](../README.md) governança e Definition of Done
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) template de pull request


### PR DESCRIPTION
 ## O que mudou
  - Consolida em um único documento as regras de branches, pull requests, revisão e integração na `main`

  ## Por quê
  - Atende o requisito da Entrega 4 de consolidar o fluxo de trabalho do repositório em um único lugar

  ## Como testar
  - Abrir `docs/fluxo-de-trabalho.md` e conferir se as seis seções cobrem os itens pedidos na descrição da entrega

  ## Auto-review (checklist)
  - [x] Descrição clara (o que / por quê / como testar)
  - [x] PR pequeno e focado
  - [x] Casos limite considerados
  - [x] Evidência de teste (revisão visual do markdown)

  ## Comentários técnicos (mínimo 3)
  - [Manutenção] O documento linka para as fontes originais em vez de duplicar conteúdo, evitando divergência futura entre
  `README.md`, `git-flow.md` e `fluxo-de-trabalho.md`.
  - [Risco] Qualquer mudança nas regras de governança precisa ser refletida em múltiplos arquivos; avaliar em um próximo PR se vale mover a seção de Governança do README para este documento e deixar só a referência.
  - [Teste] Como é documentação, não há teste automatizado; a verificação é visual e por revisão do par.