### PR TITLE
docs: adicionar ADRs 0005, 0006 e 0007

### DIFF
--- a/docs/adrs/ADR-0005-seguranca-fora-do-mvp.md
+++ b/docs/adrs/ADR-0005-seguranca-fora-do-mvp.md
@@ -1,0 +1,19 @@
+# ADR-0005: Segurança fora do MVP
+
+## Contexto
+
+O MVP será demonstrado em rede interna isolada, sem exposição à internet
+
+## Decisão
+
+TLS, autenticação e rate limit ficam fora do MVP. A API escuta HTTP puro, sem auth
+
+## Alternativas consideradas
+
+- Token fixo simples: ainda exige configuração e não resolve TLS
+- Adiar tudo para depois da primeira entrega: rejeitado, a decisão precisa ser rastreável
+
+## Consequências
+
+- Deploy trivial para a demo
+- Sistema não pode ser exposto à internet até essas camadas entrarem

--- a/docs/adrs/ADR-0006-armazenamento-sqlite.md
+++ b/docs/adrs/ADR-0006-armazenamento-sqlite.md
@@ -1,0 +1,20 @@
+# ADR-0006: SQLite como armazenamento dos documentos e anexos
+
+## Contexto
+
+Precisamos decidir onde o conteúdo markdown e os anexos embutidos ficam guardados no servidor
+
+## Decisão
+
+SQLite armazena o conteúdo dos documentos e dos anexos, além dos metadados. O ADR-0003 já escolheu SQLite como banco, aqui fica formalizado que ele também é a fonte de verdade do conteúdo
+
+## Alternativas consideradas
+
+- Filesystem no volume do servidor: exige coordenação entre disco e banco
+- Garage (object storage): serviço extra no compose sem ganho para o escopo
+
+## Consequências
+
+- Conteúdo e metadados gravados em uma única transação
+- Backup é copiar um arquivo só
+- Tamanho do banco cresce conforme o volume de anexos

--- a/docs/adrs/ADR-0007-interface-rest.md
+++ b/docs/adrs/ADR-0007-interface-rest.md
@@ -1,0 +1,17 @@
+# ADR-0007: API REST como única interface de acesso
+
+## Contexto
+
+Clientes (Obsidian, agentes de IA) podem estar em máquinas diferentes do servidor e precisam ler e escrever documentos
+
+## Decisão
+
+Toda interação com o servidor passa pela API REST. Cliente nunca acessa o armazenamento diretamente
+
+## Alternativas consideradas
+
+- Cliente acessando diretamente o armazenamento do servidor: acopla o cliente à infra e quebra com acesso remoto
+
+## Consequências
+
+- Obsidian exigirá plugin próprio para falar com o servidor


### PR DESCRIPTION
## O que mudou
- Adiciona ADR-0005: segurança fora do MVP
- Adiciona ADR-0006: SQLite como armazenamento dos documentos e anexos
- Adiciona ADR-0007: API REST como única interface de acesso
  
## Por quê
- Registrar decisões de arquitetura recentes para ficarem rastreáveis junto dos ADRs existentes

## Como testar
- Abrir cada arquivo em `docs/adrs/` e verificar se o conteúdo reflete o que foi decidido

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (não se aplica)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Manutenção] ADR-0006 fixa SQLite como fonte de verdade do conteúdo
- [Manutenção] ADR-0005 vale enquanto o MVP rodar em rede isolada, ao sair desse cenário é preciso retomar os itens
  listados
- [Teste] Evidência é revisão (leitura dos três arquivos), por ser PR só de documentação
