### PR TITLE
fix: trocar rota GET de /files/{id} para /notes/{id}

### DIFF
--- a/backend/internal/api/notes_handler_test.go
+++ b/backend/internal/api/notes_handler_test.go
@@ -118,13 +118,13 @@ func TestPostNotes_ErrDuplicatePath_Retorna409(t *testing.T) {
 func doGet(t *testing.T, svc api.NoteService, id string) *httptest.ResponseRecorder {
 	t.Helper()
 	router := api.NewRouter(svc)
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/files/%s", id), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/notes/%s", id), nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	return rec
 }
 
-func TestGetFiles_IDValido_Retorna200(t *testing.T) {
+func TestGetNotes_IDValido_Retorna200(t *testing.T) {
 	svc := &fakeService{
 		note: notes.Note{ID: "id-x", Path: "x.md", Content: "y"},
 	}
@@ -140,14 +140,14 @@ func TestGetFiles_IDValido_Retorna200(t *testing.T) {
 	assert.Equal(t, "y", resp["content"])
 }
 
-func TestGetFiles_IDVazio_Retorna404(t *testing.T) {
+func TestGetNotes_IDVazio_Retorna404(t *testing.T) {
 	svc := &fakeService{}
 	rec := doGet(t, svc, "")
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestGetFiles_IDNaoEncontrado_Retorna404(t *testing.T) {
+func TestGetNotes_IDNaoEncontrado_Retorna404(t *testing.T) {
 	svc := &fakeService{err: sql.ErrNoRows}
 	rec := doGet(t, svc, "id-inexistente")
 
@@ -171,12 +171,12 @@ func (s *stubRepository) GetNoteByID(ctx context.Context, id string) (notes.Note
 	return s.noteToReturn, s.getError
 }
 
-func TestGetFiles_IDNaoEncontrado_ComServiceReal_Retorna404(t *testing.T) {
+func TestGetNotes_IDNaoEncontrado_ComServiceReal_Retorna404(t *testing.T) {
 	repo := &stubRepository{getError: sql.ErrNoRows}
 	svc := notes.NewService(repo, 1000)
 
 	router := api.NewRouter(svc)
-	req := httptest.NewRequest(http.MethodGet, "/files/id-inexistente", nil)
+	req := httptest.NewRequest(http.MethodGet, "/notes/id-inexistente", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
@@ -187,19 +187,19 @@ func TestGetFiles_IDNaoEncontrado_ComServiceReal_Retorna404(t *testing.T) {
 	assert.Equal(t, "not_found", resp["error"])
 }
 
-func TestGetFiles_IDVazio_ComServiceReal_Retorna400(t *testing.T) {
+func TestGetNotes_IDVazio_ComServiceReal_Retorna400(t *testing.T) {
 	repo := &stubRepository{}
 	svc := notes.NewService(repo, 1000)
 
 	router := api.NewRouter(svc)
-	req := httptest.NewRequest(http.MethodGet, "/files/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/notes/", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestGetFiles_IDValido_ComServiceReal_Retorna200(t *testing.T) {
+func TestGetNotes_IDValido_ComServiceReal_Retorna200(t *testing.T) {
 	notaEsperada := notes.Note{
 		ID:      "id-123",
 		Path:    "file.md",
@@ -209,7 +209,7 @@ func TestGetFiles_IDValido_ComServiceReal_Retorna200(t *testing.T) {
 	svc := notes.NewService(repo, 1000)
 
 	router := api.NewRouter(svc)
-	req := httptest.NewRequest(http.MethodGet, "/files/id-123", nil)
+	req := httptest.NewRequest(http.MethodGet, "/notes/id-123", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -12,7 +12,7 @@ func NewRouter(svc NoteService) chi.Router {
 
 	h := &notesHandler{svc: svc}
 	r.Post("/notes", h.create)
-	r.Get("/files/{id}", h.get)
+	r.Get("/notes/{id}", h.get)
 
 	return r
 }


### PR DESCRIPTION
## O que mudou
- `GET /files/{id}` virou `GET /notes/{id}` em `backend/internal/api/router.go`
- Testes do handler ajustados (paths e nomes `TestGetFiles_*` para `TestGetNotes_*`)

## Por quê
- Padronizar com as demais rotas de notas (`POST /notes` e `PUT/DELETE /notes/{id}` no PR #54)
- Closes #55

## Como testar
- `cd backend && go test ./...` passa
- Manual: `curl -i http://localhost:8080/notes/<id>` responde 200; `curl -i http://localhost:8080/files/<id>` agora 404

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Risco] Quebra qualquer cliente que ainda chame `/files/{id}`. Como o backend não está em produção e o plugin ainda não consome essa rota, impacto é zero.
- [Manutenção] PR #54 mexe nas mesmas linhas de `router.go` e do handler. Provável conflito trivial no rebase: as rotas devem terminar agrupadas em `/notes` e `/notes/{id}`.
- [Teste] Cobertura mantida: os 6 testes da rota GET continuam rodando, só caminhos e nomes das funções mudaram.