### PR TITLE
Feat/sincronização plugin servidor

### DIFF
--- a/backend/internal/api/integration_test.go
+++ b/backend/internal/api/integration_test.go
@@ -198,3 +198,49 @@ func TestIntegration_CriarNotaDuplicada_RetornaMensagemLimpa(t *testing.T) {
 	msg, _ := errBody["message"].(string)
 	assert.NotContains(t, msg, "salvar nota")
 }
+
+func TestIntegration_ListNotes_DBVazio_RetornaArrayVazio(t *testing.T) {
+	server, _ := setupIntegrationServer(t)
+
+	resp, err := http.Get(server.URL + "/notes")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var arr []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&arr))
+	assert.Empty(t, arr)
+}
+
+func TestIntegration_ListNotes_RetornaArrayOrdenadoPorPath(t *testing.T) {
+	server, _ := setupIntegrationServer(t)
+
+	r1 := postNotes(t, server.URL, `{"path":"zebra.md","content":"z"}`)
+	require.Equal(t, http.StatusCreated, r1.StatusCode)
+	_ = r1.Body.Close()
+
+	r2 := postNotes(t, server.URL, `{"path":"alfa.md","content":"a"}`)
+	require.Equal(t, http.StatusCreated, r2.StatusCode)
+	_ = r2.Body.Close()
+
+	r3 := postNotes(t, server.URL, `{"path":"meio.md","content":"m"}`)
+	require.Equal(t, http.StatusCreated, r3.StatusCode)
+	_ = r3.Body.Close()
+
+	resp, err := http.Get(server.URL + "/notes")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var arr []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&arr))
+	require.Len(t, arr, 3)
+	assert.Equal(t, "alfa.md", arr[0]["path"])
+	assert.Equal(t, "meio.md", arr[1]["path"])
+	assert.Equal(t, "zebra.md", arr[2]["path"])
+	assert.Equal(t, "a", arr[0]["content"])
+	assert.Equal(t, "m", arr[1]["content"])
+	assert.Equal(t, "z", arr[2]["content"])
+}

--- a/backend/internal/api/notes_handler.go
+++ b/backend/internal/api/notes_handler.go
@@ -18,6 +18,7 @@ type NoteService interface {
 	Update(ctx context.Context, id, path, content string) (notes.Note, error)
 	Delete(ctx context.Context, id string) error
 	GetNoteById(ctx context.Context, id string) (notes.Note, error)
+	ListNotes(ctx context.Context) ([]notes.Note, error)
 }
 
 type notesHandler struct {
@@ -90,6 +91,19 @@ func (h *notesHandler) get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, toResponse(note))
+}
+
+func (h *notesHandler) list(w http.ResponseWriter, r *http.Request) {
+	list, err := h.svc.ListNotes(r.Context())
+	if err != nil {
+		writeDomainError(w, err)
+		return
+	}
+	out := make([]noteResponse, 0, len(list))
+	for _, n := range list {
+		out = append(out, toResponse(n))
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
 func (h *notesHandler) delete(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/notes_handler_test.go
+++ b/backend/internal/api/notes_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +35,10 @@ type fakeService struct {
 	deleteErr    error
 	deleteCalled bool
 	deletedID    string
+
+	listResult []notes.Note
+	listErr    error
+	listCalled bool
 }
 
 func (f *fakeService) Create(ctx context.Context, path, content string) (notes.Note, error) {
@@ -56,6 +61,11 @@ func (f *fakeService) Delete(ctx context.Context, id string) error {
 
 func (f *fakeService) GetNoteById(ctx context.Context, id string) (notes.Note, error) {
 	return f.note, f.err
+}
+
+func (f *fakeService) ListNotes(ctx context.Context) ([]notes.Note, error) {
+	f.listCalled = true
+	return f.listResult, f.listErr
 }
 
 func doPost(t *testing.T, svc api.NoteService, body string) *httptest.ResponseRecorder {
@@ -91,6 +101,15 @@ func doGet(t *testing.T, svc api.NoteService, id string) *httptest.ResponseRecor
 	t.Helper()
 	router := api.NewRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/notes/%s", id), nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func doListNotes(t *testing.T, svc api.NoteService) *httptest.ResponseRecorder {
+	t.Helper()
+	router := api.NewRouter(svc)
+	req := httptest.NewRequest(http.MethodGet, "/notes", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	return rec
@@ -275,6 +294,9 @@ func TestGetNotes_IDNaoEncontrado_Retorna404(t *testing.T) {
 type stubRepository struct {
 	noteToReturn notes.Note
 	getError     error
+
+	listResult []notes.Note
+	listErr    error
 }
 
 func (s *stubRepository) Save(ctx context.Context, n notes.Note) error {
@@ -291,6 +313,10 @@ func (s *stubRepository) Delete(ctx context.Context, id string) error {
 
 func (s *stubRepository) GetNoteByID(ctx context.Context, id string) (notes.Note, error) {
 	return s.noteToReturn, s.getError
+}
+
+func (s *stubRepository) ListNotes(ctx context.Context) ([]notes.Note, error) {
+	return s.listResult, s.listErr
 }
 
 func TestGetNotes_IDNaoEncontrado_ComServiceReal_Retorna404(t *testing.T) {
@@ -342,4 +368,45 @@ func TestGetNotes_IDValido_ComServiceReal_Retorna200(t *testing.T) {
 	assert.Equal(t, "id-123", resp["id"])
 	assert.Equal(t, "file.md", resp["path"])
 	assert.Equal(t, "conteudo", resp["content"])
+}
+
+func TestListNotes_DBVazio_Retorna200ComArrayVazio(t *testing.T) {
+	svc := &fakeService{listResult: []notes.Note{}}
+	rec := doListNotes(t, svc)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var resp []map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp)
+	assert.True(t, svc.listCalled)
+}
+
+func TestListNotes_ComNotas_RetornaArrayCompleto(t *testing.T) {
+	svc := &fakeService{listResult: []notes.Note{
+		{ID: "id-1", Path: "a.md", Content: "aaa"},
+		{ID: "id-2", Path: "b.md", Content: "bbb"},
+	}}
+	rec := doListNotes(t, svc)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp, 2)
+	assert.Equal(t, "id-1", resp[0]["id"])
+	assert.Equal(t, "a.md", resp[0]["path"])
+	assert.Equal(t, "aaa", resp[0]["content"])
+	assert.Equal(t, "id-2", resp[1]["id"])
+}
+
+func TestListNotes_ServiceRetornaErro_Retorna500(t *testing.T) {
+	svc := &fakeService{listErr: errors.New("erro inesperado")}
+	rec := doListNotes(t, svc)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "internal", resp["error"])
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -12,6 +12,7 @@ func NewRouter(svc NoteService) chi.Router {
 
 	h := &notesHandler{svc: svc}
 	r.Post("/notes", h.create)
+	r.Get("/notes", h.list)
 	r.Get("/notes/{id}", h.get)
 	r.Put("/notes/{id}", h.update)
 	r.Delete("/notes/{id}", h.delete)

--- a/backend/internal/notes/notes.go
+++ b/backend/internal/notes/notes.go
@@ -24,6 +24,7 @@ type Repository interface {
 	Update(ctx context.Context, id, path, content string, updatedAt time.Time) (Note, error)
 	Delete(ctx context.Context, id string) error
 	GetNoteByID(ctx context.Context, id string) (Note, error)
+	ListNotes(ctx context.Context) ([]Note, error)
 }
 
 var (
@@ -61,6 +62,10 @@ func (s *Service) GetNoteById(ctx context.Context, id string) (Note, error) {
 		return Note{}, ErrNotFoundId
 	}
 	return note, err
+}
+
+func (s *Service) ListNotes(ctx context.Context) ([]Note, error) {
+	return s.repo.ListNotes(ctx)
 }
 
 func (s *Service) Create(ctx context.Context, path, content string) (Note, error) {

--- a/backend/internal/notes/service_test.go
+++ b/backend/internal/notes/service_test.go
@@ -37,6 +37,10 @@ type fakeRepo struct {
 
 	note   notes.Note
 	getErr error
+
+	listResult []notes.Note
+	listErr    error
+	listCalled bool
 }
 
 func (f *fakeRepo) Save(ctx context.Context, n notes.Note) error {
@@ -62,6 +66,11 @@ func (f *fakeRepo) Delete(ctx context.Context, id string) error {
 
 func (f *fakeRepo) GetNoteByID(ctx context.Context, id string) (notes.Note, error) {
 	return f.note, f.getErr
+}
+
+func (f *fakeRepo) ListNotes(ctx context.Context) ([]notes.Note, error) {
+	f.listCalled = true
+	return f.listResult, f.listErr
 }
 
 func newServiceForTest(repo notes.Repository) *notes.Service {
@@ -295,4 +304,38 @@ func TestGetNoteById_CaminhoFeliz_RetornaNotaCorreta(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, notaEsperada, nota)
+}
+
+func TestListNotes_DelegaParaRepo_RetornaLista(t *testing.T) {
+	esperadas := []notes.Note{
+		{ID: "id-1", Path: "a.md", Content: "1"},
+		{ID: "id-2", Path: "b.md", Content: "2"},
+	}
+	repo := &fakeRepo{listResult: esperadas}
+	svc := newServiceForTest(repo)
+
+	got, err := svc.ListNotes(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, repo.listCalled)
+	assert.Equal(t, esperadas, got)
+}
+
+func TestListNotes_RepoRetornaErro_Propagado(t *testing.T) {
+	repo := &fakeRepo{listErr: errors.New("falha no repo")}
+	svc := newServiceForTest(repo)
+
+	_, err := svc.ListNotes(context.Background())
+
+	require.Error(t, err)
+}
+
+func TestListNotes_DBVazio_RetornaSliceVazio(t *testing.T) {
+	repo := &fakeRepo{listResult: []notes.Note{}}
+	svc := newServiceForTest(repo)
+
+	got, err := svc.ListNotes(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }

--- a/backend/internal/storage/gen/notes.sql.go
+++ b/backend/internal/storage/gen/notes.sql.go
@@ -63,6 +63,40 @@ func (q *Queries) GetNoteByID(ctx context.Context, id string) (Note, error) {
 	return i, err
 }
 
+const listNotes = `-- name: ListNotes :many
+SELECT id, path, content, created_at, updated_at FROM notes
+ORDER BY path
+`
+
+func (q *Queries) ListNotes(ctx context.Context) ([]Note, error) {
+	rows, err := q.db.QueryContext(ctx, listNotes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Note{}
+	for rows.Next() {
+		var i Note
+		if err := rows.Scan(
+			&i.ID,
+			&i.Path,
+			&i.Content,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateNote = `-- name: UpdateNote :one
 UPDATE notes
 SET path = ?, content = ?, updated_at = ?

--- a/backend/internal/storage/notes.go
+++ b/backend/internal/storage/notes.go
@@ -89,6 +89,24 @@ func (r *SqliteNotesRepository) GetNoteByID(ctx context.Context, id string) (not
 	}, nil
 }
 
+func (r *SqliteNotesRepository) ListNotes(ctx context.Context) ([]notes.Note, error) {
+	rows, err := r.q.ListNotes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]notes.Note, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, notes.Note{
+			ID:        row.ID,
+			Path:      row.Path,
+			Content:   row.Content,
+			CreatedAt: row.CreatedAt,
+			UpdatedAt: row.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
 func isUniqueConstraintViolation(err error) bool {
 	var sqliteErr *sqlite.Error
 	if !errors.As(err, &sqliteErr) {

--- a/backend/internal/storage/notes_test.go
+++ b/backend/internal/storage/notes_test.go
@@ -147,3 +147,37 @@ func TestSqliteRepo_Delete_IDInexistente_RetornaErrNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, notes.ErrNotFound))
 }
+
+func TestSqliteRepo_ListNotes_DBVazio_RetornaSliceVazio(t *testing.T) {
+	db := setupTestDB(t)
+	repo := storage.NewSqliteNotesRepository(db)
+
+	got, err := repo.ListNotes(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestSqliteRepo_ListNotes_RetornaTodasNotasOrdenadasPorPath(t *testing.T) {
+	db := setupTestDB(t)
+	repo := storage.NewSqliteNotesRepository(db)
+	now := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+
+	notas := []notes.Note{
+		{ID: "id-c", Path: "c.md", Content: "ccc", CreatedAt: now, UpdatedAt: now},
+		{ID: "id-a", Path: "a.md", Content: "aaa", CreatedAt: now, UpdatedAt: now},
+		{ID: "id-b", Path: "b.md", Content: "bbb", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, n := range notas {
+		require.NoError(t, repo.Save(context.Background(), n))
+	}
+
+	got, err := repo.ListNotes(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "a.md", got[0].Path)
+	assert.Equal(t, "b.md", got[1].Path)
+	assert.Equal(t, "c.md", got[2].Path)
+	assert.Equal(t, "aaa", got[0].Content)
+}

--- a/backend/internal/storage/queries/notes.sql
+++ b/backend/internal/storage/queries/notes.sql
@@ -5,6 +5,10 @@ VALUES (?, ?, ?, ?, ?);
 -- name: GetNoteByID :one
 SELECT id, path, content, created_at, updated_at FROM notes WHERE id = ?;
 
+-- name: ListNotes :many
+SELECT id, path, content, created_at, updated_at FROM notes
+ORDER BY path;
+
 -- name: UpdateNote :one
 UPDATE notes
 SET path = ?, content = ?, updated_at = ?

--- a/obsidian-plugin/package-lock.json
+++ b/obsidian-plugin/package-lock.json
@@ -1524,9 +1524,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1534,13 +1534,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -1745,9 +1745,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2007,9 +2007,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2848,9 +2848,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2865,9 +2865,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2882,9 +2882,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-			"integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+			"version": "8.0.7",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+			"integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2924,9 +2924,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2947,13 +2947,13 @@
 			}
 		},
 		"node_modules/eslint-plugin-n/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -3287,9 +3287,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3371,9 +3371,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -4263,9 +4263,9 @@
 			}
 		},
 		"node_modules/json-schema-migrate/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4799,9 +4799,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5141,9 +5141,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7086,9 +7086,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7096,6 +7096,9 @@
 			},
 			"engines": {
 				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yaml-eslint-parser": {

--- a/obsidian-plugin/src/__mocks__/fake-plugin.ts
+++ b/obsidian-plugin/src/__mocks__/fake-plugin.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { TAbstractFile, TFile, TFolder } from "./obsidian";
 
 export type FakeFile = {
 	path: string;
@@ -8,6 +9,7 @@ export type FakeFile = {
 export type FakePluginOptions = {
 	file?: FakeFile | null;
 	fileContent?: string;
+	vaultFiles?: Record<string, TAbstractFile>;
 };
 
 export function makeFakePlugin(opts: FakePluginOptions = {}) {
@@ -17,10 +19,29 @@ export function makeFakePlugin(opts: FakePluginOptions = {}) {
 			: opts.file;
 	const view = file ? { file } : null;
 
+	const vaultFiles = new Map<string, TAbstractFile>(
+		Object.entries(opts.vaultFiles ?? {}),
+	);
+
 	const vault = {
 		read: vi.fn().mockResolvedValue(opts.fileContent ?? ""),
-		modify: vi.fn().mockImplementation(async (f: FakeFile, _: string) => {
+		modify: vi.fn().mockImplementation(async (f: FakeFile | TFile, _: string) => {
 			if (f) f.stat.mtime = f.stat.mtime + 1000;
+		}),
+		getAbstractFileByPath: vi
+			.fn()
+			.mockImplementation((path: string) => vaultFiles.get(path) ?? null),
+		create: vi
+			.fn()
+			.mockImplementation(async (path: string, _content: string) => {
+				const tfile = new TFile(path, 5000);
+				vaultFiles.set(path, tfile);
+				return tfile;
+			}),
+		createFolder: vi.fn().mockImplementation(async (path: string) => {
+			const tfolder = new TFolder(path);
+			vaultFiles.set(path, tfolder);
+			return tfolder;
 		}),
 	};
 	const workspace = {
@@ -31,5 +52,5 @@ export function makeFakePlugin(opts: FakePluginOptions = {}) {
 		saveData: vi.fn().mockResolvedValue(undefined),
 	};
 
-	return { plugin, vault, workspace, file };
+	return { plugin, vault, workspace, file, vaultFiles };
 }

--- a/obsidian-plugin/src/__mocks__/fake-plugin.ts
+++ b/obsidian-plugin/src/__mocks__/fake-plugin.ts
@@ -1,0 +1,35 @@
+import { vi } from "vitest";
+
+export type FakeFile = {
+	path: string;
+	stat: { mtime: number };
+};
+
+export type FakePluginOptions = {
+	file?: FakeFile | null;
+	fileContent?: string;
+};
+
+export function makeFakePlugin(opts: FakePluginOptions = {}) {
+	const file =
+		opts.file === undefined
+			? { path: "default.md", stat: { mtime: 1000 } }
+			: opts.file;
+	const view = file ? { file } : null;
+
+	const vault = {
+		read: vi.fn().mockResolvedValue(opts.fileContent ?? ""),
+		modify: vi.fn().mockImplementation(async (f: FakeFile, _: string) => {
+			if (f) f.stat.mtime = f.stat.mtime + 1000;
+		}),
+	};
+	const workspace = {
+		getActiveViewOfType: vi.fn().mockReturnValue(view),
+	};
+	const plugin = {
+		app: { vault, workspace },
+		saveData: vi.fn().mockResolvedValue(undefined),
+	};
+
+	return { plugin, vault, workspace, file };
+}

--- a/obsidian-plugin/src/__mocks__/obsidian.ts
+++ b/obsidian-plugin/src/__mocks__/obsidian.ts
@@ -17,7 +17,26 @@ export class Notice {
 export class Plugin {}
 export class MarkdownView {}
 export class PluginSettingTab {}
-export class TAbstractFile {}
+
+export class TAbstractFile {
+	path: string = "";
+}
+
+export class TFile extends TAbstractFile {
+	stat: { mtime: number };
+	constructor(path: string = "", mtime: number = 0) {
+		super();
+		this.path = path;
+		this.stat = { mtime };
+	}
+}
+
+export class TFolder extends TAbstractFile {
+	constructor(path: string = "") {
+		super();
+		this.path = path;
+	}
+}
 
 export class Setting {
 	setName() {
@@ -33,6 +52,9 @@ export class Setting {
 
 export class Menu {
 	addItem() {
+		return this;
+	}
+	addSeparator() {
 		return this;
 	}
 	showAtMouseEvent() {

--- a/obsidian-plugin/src/__mocks__/obsidian.ts
+++ b/obsidian-plugin/src/__mocks__/obsidian.ts
@@ -2,15 +2,22 @@ import { vi } from "vitest";
 
 export const requestUrl = vi.fn();
 
+export const noticeCalls: string[] = [];
+
+export function clearNoticeCalls(): void {
+	noticeCalls.length = 0;
+}
+
 export class Notice {
-	constructor(public message: string) {}
+	constructor(public message: string) {
+		noticeCalls.push(message);
+	}
 }
 
 export class Plugin {}
-
 export class MarkdownView {}
-
 export class PluginSettingTab {}
+export class TAbstractFile {}
 
 export class Setting {
 	setName() {
@@ -20,6 +27,15 @@ export class Setting {
 		return this;
 	}
 	addText() {
+		return this;
+	}
+}
+
+export class Menu {
+	addItem() {
+		return this;
+	}
+	showAtMouseEvent() {
 		return this;
 	}
 }

--- a/obsidian-plugin/src/api/client.test.ts
+++ b/obsidian-plugin/src/api/client.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { requestUrl } from "obsidian";
-import { createNote, MarkuppApiError } from "./client";
+import { createNote, getNote, MarkuppApiError, updateNote } from "./client";
 
 vi.mock("obsidian", () => import("../__mocks__/obsidian"));
 
 const mockRequestUrl = vi.mocked(requestUrl);
+
+const noteResponse = {
+	id: "abc",
+	path: "foo.md",
+	content: "hello",
+	created_at: "2026-05-06T00:00:00Z",
+	updated_at: "2026-05-06T00:00:00Z",
+};
 
 describe("createNote", () => {
 	beforeEach(() => {
@@ -12,18 +20,11 @@ describe("createNote", () => {
 	});
 
 	test("retorna NoteResponse quando status 201", async () => {
-		const note = {
-			id: "abc",
-			path: "foo.md",
-			content: "hello",
-			created_at: "2026-05-06T00:00:00Z",
-			updated_at: "2026-05-06T00:00:00Z",
-		};
-		mockRequestUrl.mockResolvedValue({ status: 201, json: note });
+		mockRequestUrl.mockResolvedValue({ status: 201, json: noteResponse });
 
 		const result = await createNote("http://localhost:8080", "foo.md", "hello");
 
-		expect(result).toEqual(note);
+		expect(result).toEqual(noteResponse);
 		expect(mockRequestUrl).toHaveBeenCalledWith({
 			url: "http://localhost:8080/notes",
 			method: "POST",
@@ -69,6 +70,110 @@ describe("createNote", () => {
 			code: "unknown",
 			message: "Erro desconhecido",
 			status: 500,
+		});
+	});
+});
+
+describe("updateNote", () => {
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+	});
+
+	test("retorna NoteResponse quando status 200", async () => {
+		mockRequestUrl.mockResolvedValue({ status: 200, json: noteResponse });
+
+		const result = await updateNote(
+			"http://localhost:8080",
+			"abc",
+			"foo.md",
+			"hello",
+		);
+
+		expect(result).toEqual(noteResponse);
+		expect(mockRequestUrl).toHaveBeenCalledWith({
+			url: "http://localhost:8080/notes/abc",
+			method: "PUT",
+			contentType: "application/json",
+			body: JSON.stringify({ path: "foo.md", content: "hello" }),
+			throw: false,
+		});
+	});
+
+	test("normaliza barras finais da backendUrl", async () => {
+		mockRequestUrl.mockResolvedValue({ status: 200, json: {} });
+
+		await updateNote("http://localhost:8080///", "abc", "foo.md", "x");
+
+		expect(mockRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({ url: "http://localhost:8080/notes/abc" }),
+		);
+	});
+
+	test("aplica encodeURIComponent no id", async () => {
+		mockRequestUrl.mockResolvedValue({ status: 200, json: {} });
+
+		await updateNote("http://localhost:8080", "a/b", "foo.md", "x");
+
+		expect(mockRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({ url: "http://localhost:8080/notes/a%2Fb" }),
+		);
+	});
+
+	test("lança MarkuppApiError com código e mensagem do servidor", async () => {
+		mockRequestUrl.mockResolvedValue({
+			status: 404,
+			json: { error: "not_found", message: "nota não encontrada" },
+		});
+
+		await expect(
+			updateNote("http://localhost:8080", "x", "foo.md", "y"),
+		).rejects.toMatchObject({
+			name: "MarkuppApiError",
+			code: "not_found",
+			status: 404,
+		});
+	});
+});
+
+describe("getNote", () => {
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+	});
+
+	test("retorna NoteResponse quando status 200", async () => {
+		mockRequestUrl.mockResolvedValue({ status: 200, json: noteResponse });
+
+		const result = await getNote("http://localhost:8080", "abc");
+
+		expect(result).toEqual(noteResponse);
+		expect(mockRequestUrl).toHaveBeenCalledWith({
+			url: "http://localhost:8080/notes/abc",
+			method: "GET",
+			throw: false,
+		});
+	});
+
+	test("normaliza barras finais da backendUrl", async () => {
+		mockRequestUrl.mockResolvedValue({ status: 200, json: {} });
+
+		await getNote("http://localhost:8080///", "abc");
+
+		expect(mockRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({ url: "http://localhost:8080/notes/abc" }),
+		);
+	});
+
+	test("lança MarkuppApiError com código e mensagem do servidor", async () => {
+		mockRequestUrl.mockResolvedValue({
+			status: 404,
+			json: { error: "not_found", message: "nota não encontrada" },
+		});
+
+		await expect(
+			getNote("http://localhost:8080", "x"),
+		).rejects.toMatchObject({
+			code: "not_found",
+			status: 404,
 		});
 	});
 });

--- a/obsidian-plugin/src/api/client.test.ts
+++ b/obsidian-plugin/src/api/client.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { requestUrl } from "obsidian";
-import { createNote, getNote, MarkuppApiError, updateNote } from "./client";
+import {
+	createNote,
+	getNote,
+	listNotes,
+	MarkuppApiError,
+	updateNote,
+} from "./client";
 
 vi.mock("obsidian", () => import("../__mocks__/obsidian"));
 
@@ -174,6 +180,61 @@ describe("getNote", () => {
 		).rejects.toMatchObject({
 			code: "not_found",
 			status: 404,
+		});
+	});
+});
+
+describe("listNotes", () => {
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+	});
+
+	test("retorna NoteResponse[] quando status 200", async () => {
+		const list = [
+			noteResponse,
+			{ ...noteResponse, id: "abc-2", path: "outra.md" },
+		];
+		mockRequestUrl.mockResolvedValue({ status: 200, json: list });
+
+		const result = await listNotes("http://localhost:8080");
+
+		expect(result).toEqual(list);
+		expect(mockRequestUrl).toHaveBeenCalledWith({
+			url: "http://localhost:8080/notes",
+			method: "GET",
+			throw: false,
+		});
+	});
+
+	test("normaliza barras finais da backendUrl", async () => {
+		mockRequestUrl.mockResolvedValue({ status: 200, json: [] });
+
+		await listNotes("http://localhost:8080///");
+
+		expect(mockRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({ url: "http://localhost:8080/notes" }),
+		);
+	});
+
+	test("lista vazia retorna array vazio", async () => {
+		mockRequestUrl.mockResolvedValue({ status: 200, json: [] });
+
+		const result = await listNotes("http://localhost:8080");
+
+		expect(result).toEqual([]);
+	});
+
+	test("lança MarkuppApiError quando servidor retorna erro", async () => {
+		mockRequestUrl.mockResolvedValue({
+			status: 500,
+			json: { error: "internal", message: "erro interno" },
+		});
+
+		await expect(
+			listNotes("http://localhost:8080"),
+		).rejects.toMatchObject({
+			code: "internal",
+			status: 500,
 		});
 	});
 });

--- a/obsidian-plugin/src/api/client.ts
+++ b/obsidian-plugin/src/api/client.ts
@@ -86,3 +86,16 @@ export async function getNote(
 	}
 	throw toApiError(res);
 }
+
+export async function listNotes(backendUrl: string): Promise<NoteResponse[]> {
+	const res = await requestUrl({
+		url: notesUrl(backendUrl),
+		method: "GET",
+		throw: false,
+	});
+
+	if (res.status === 200) {
+		return res.json as NoteResponse[];
+	}
+	throw toApiError(res);
+}

--- a/obsidian-plugin/src/api/client.ts
+++ b/obsidian-plugin/src/api/client.ts
@@ -19,14 +19,26 @@ export class MarkuppApiError extends Error {
 	}
 }
 
+function notesUrl(backendUrl: string, suffix = ""): string {
+	return backendUrl.replace(/\/+$/, "") + "/notes" + suffix;
+}
+
+function toApiError(res: { status: number; json: unknown }): MarkuppApiError {
+	const body = res.json as { error?: string; message?: string } | undefined;
+	return new MarkuppApiError(
+		body?.error ?? "unknown",
+		body?.message ?? "Erro desconhecido",
+		res.status,
+	);
+}
+
 export async function createNote(
 	backendUrl: string,
 	path: string,
 	content: string,
 ): Promise<NoteResponse> {
-	const url = backendUrl.replace(/\/+$/, "") + "/notes";
 	const res = await requestUrl({
-		url,
+		url: notesUrl(backendUrl),
 		method: "POST",
 		contentType: "application/json",
 		body: JSON.stringify({ path, content }),
@@ -36,11 +48,41 @@ export async function createNote(
 	if (res.status === 201) {
 		return res.json as NoteResponse;
 	}
+	throw toApiError(res);
+}
 
-	const body = res.json as { error?: string; message?: string } | undefined;
-	throw new MarkuppApiError(
-		body?.error ?? "unknown",
-		body?.message ?? "Erro desconhecido",
-		res.status,
-	);
+export async function updateNote(
+	backendUrl: string,
+	id: string,
+	path: string,
+	content: string,
+): Promise<NoteResponse> {
+	const res = await requestUrl({
+		url: notesUrl(backendUrl, "/" + encodeURIComponent(id)),
+		method: "PUT",
+		contentType: "application/json",
+		body: JSON.stringify({ path, content }),
+		throw: false,
+	});
+
+	if (res.status === 200) {
+		return res.json as NoteResponse;
+	}
+	throw toApiError(res);
+}
+
+export async function getNote(
+	backendUrl: string,
+	id: string,
+): Promise<NoteResponse> {
+	const res = await requestUrl({
+		url: notesUrl(backendUrl, "/" + encodeURIComponent(id)),
+		method: "GET",
+		throw: false,
+	});
+
+	if (res.status === 200) {
+		return res.json as NoteResponse;
+	}
+	throw toApiError(res);
 }

--- a/obsidian-plugin/src/commands/download.test.ts
+++ b/obsidian-plugin/src/commands/download.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as client from "../api/client";
+import { MarkuppApiError } from "../api/client";
+import type { MarkuppSettings, NoteMeta } from "../settings";
+import { makeFakePlugin } from "../__mocks__/fake-plugin";
+import { clearNoticeCalls, noticeCalls } from "../__mocks__/obsidian";
+import { downloadActiveNote } from "./download";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+vi.mock("../api/client", async () => {
+	const actual =
+		await vi.importActual<typeof import("../api/client")>("../api/client");
+	return {
+		...actual,
+		createNote: vi.fn(),
+		updateNote: vi.fn(),
+		getNote: vi.fn(),
+	};
+});
+
+const getNote = vi.mocked(client.getNote);
+
+beforeEach(() => {
+	getNote.mockReset();
+	clearNoticeCalls();
+});
+
+function makeSettings(notes: Record<string, NoteMeta> = {}): MarkuppSettings {
+	return { backendUrl: "http://localhost:8080", notes };
+}
+
+describe("downloadActiveNote", () => {
+	test("sem meta: Notice 'use Subir primeiro' e não chama API", async () => {
+		const { plugin } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+		});
+		const settings = makeSettings();
+
+		await downloadActiveNote(plugin as never, settings);
+
+		expect(getNote).not.toHaveBeenCalled();
+		expect(plugin.saveData).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("nunca sincronizada"),
+		);
+	});
+
+	test("com meta: GET, vault.modify e meta atualizada com mtime pós-modify", async () => {
+		const { plugin, vault, file } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+		});
+		const settings = makeSettings({
+			"foo.md": { id: "srv-id", serverUpdatedAt: "old", localMtimeAtSync: 1700 },
+		});
+		getNote.mockResolvedValue({
+			id: "srv-id",
+			path: "foo.md",
+			content: "from server",
+			created_at: "T0",
+			updated_at: "T2",
+		});
+
+		await downloadActiveNote(plugin as never, settings);
+
+		expect(getNote).toHaveBeenCalledWith("http://localhost:8080", "srv-id");
+		expect(vault.modify).toHaveBeenCalledWith(file, "from server");
+		expect(settings.notes["foo.md"]).toEqual({
+			id: "srv-id",
+			serverUpdatedAt: "T2",
+			localMtimeAtSync: file!.stat.mtime,
+		});
+		expect(plugin.saveData).toHaveBeenCalled();
+	});
+
+	test("not_found: limpa meta local", async () => {
+		const { plugin } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+		});
+		const settings = makeSettings({
+			"foo.md": { id: "ghost", serverUpdatedAt: "x", localMtimeAtSync: 1500 },
+		});
+		getNote.mockRejectedValue(
+			new MarkuppApiError("not_found", "nota não encontrada", 404),
+		);
+
+		await downloadActiveNote(plugin as never, settings);
+
+		expect(settings.notes["foo.md"]).toBeUndefined();
+		expect(plugin.saveData).toHaveBeenCalled();
+	});
+
+	test("sem nota ativa: Notice e nenhuma chamada de API", async () => {
+		const { plugin } = makeFakePlugin({ file: null });
+		const settings = makeSettings();
+
+		await downloadActiveNote(plugin as never, settings);
+
+		expect(getNote).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("Nenhuma nota ativa"),
+		);
+	});
+});

--- a/obsidian-plugin/src/commands/download.ts
+++ b/obsidian-plugin/src/commands/download.ts
@@ -1,0 +1,64 @@
+import { MarkdownView, Notice, Plugin } from "obsidian";
+import { getNote, MarkuppApiError } from "../api/client";
+import { MarkuppSettings } from "../settings";
+import {
+	getNoteMeta,
+	removeNoteMeta,
+	setNoteMeta,
+} from "../storage/note-index";
+
+export async function downloadActiveNote(
+	plugin: Plugin,
+	settings: MarkuppSettings,
+): Promise<void> {
+	const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+	if (!view || !view.file) {
+		new Notice("Nenhuma nota ativa");
+		return;
+	}
+
+	const file = view.file;
+	const path = file.path;
+	const meta = getNoteMeta(settings, path);
+
+	if (!meta) {
+		new Notice("Nota nunca sincronizada — use Subir primeiro.");
+		return;
+	}
+
+	try {
+		const note = await getNote(settings.backendUrl, meta.id);
+		await plugin.app.vault.modify(file, note.content);
+
+		setNoteMeta(settings, path, {
+			id: note.id,
+			serverUpdatedAt: note.updated_at,
+			localMtimeAtSync: file.stat.mtime,
+		});
+		await plugin.saveData(settings);
+		new Notice(`Nota baixada: ${path}`);
+	} catch (err) {
+		if (
+			err instanceof MarkuppApiError &&
+			(err.code === "not_found" || err.code === "invalid_id")
+		) {
+			removeNoteMeta(settings, path);
+			await plugin.saveData(settings);
+		}
+		new Notice(buildErrorMessage(err, settings.backendUrl));
+	}
+}
+
+function buildErrorMessage(err: unknown, backendUrl: string): string {
+	if (err instanceof MarkuppApiError) {
+		switch (err.code) {
+			case "not_found":
+				return "Servidor não tem mais essa nota — referência local removida.";
+			case "invalid_id":
+				return "Id inválido no servidor — referência local removida.";
+			default:
+				return `Erro do servidor (${err.status}): ${err.message}`;
+		}
+	}
+	return `Não foi possível conectar a ${backendUrl}. Verifique se o backend está rodando.`;
+}

--- a/obsidian-plugin/src/commands/download.ts
+++ b/obsidian-plugin/src/commands/download.ts
@@ -22,7 +22,7 @@ export async function downloadActiveNote(
 	const meta = getNoteMeta(settings, path);
 
 	if (!meta) {
-		new Notice("Nota nunca sincronizada — use Subir primeiro.");
+		new Notice("Nota nunca sincronizada — envie ela primeiro.");
 		return;
 	}
 

--- a/obsidian-plugin/src/commands/import.test.ts
+++ b/obsidian-plugin/src/commands/import.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as client from "../api/client";
+import { MarkuppApiError } from "../api/client";
+import type { MarkuppSettings, NoteMeta } from "../settings";
+import { makeFakePlugin } from "../__mocks__/fake-plugin";
+import {
+	clearNoticeCalls,
+	noticeCalls,
+	TFile,
+} from "../__mocks__/obsidian";
+import { importFromServer } from "./import";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+vi.mock("../api/client", async () => {
+	const actual =
+		await vi.importActual<typeof import("../api/client")>("../api/client");
+	return {
+		...actual,
+		listNotes: vi.fn(),
+		createNote: vi.fn(),
+		updateNote: vi.fn(),
+		getNote: vi.fn(),
+	};
+});
+
+const listNotes = vi.mocked(client.listNotes);
+
+beforeEach(() => {
+	listNotes.mockReset();
+	clearNoticeCalls();
+});
+
+function makeSettings(notes: Record<string, NoteMeta> = {}): MarkuppSettings {
+	return { backendUrl: "http://localhost:8080", notes };
+}
+
+describe("importFromServer", () => {
+	test("vault vazio: cria todos os arquivos e popula meta", async () => {
+		const { plugin, vault } = makeFakePlugin();
+		const settings = makeSettings();
+		listNotes.mockResolvedValue([
+			{
+				id: "a",
+				path: "a.md",
+				content: "alpha",
+				created_at: "T0",
+				updated_at: "T1",
+			},
+			{
+				id: "b",
+				path: "b.md",
+				content: "beta",
+				created_at: "T0",
+				updated_at: "T1",
+			},
+		]);
+
+		await importFromServer(plugin as never, settings);
+
+		expect(vault.create).toHaveBeenCalledWith("a.md", "alpha");
+		expect(vault.create).toHaveBeenCalledWith("b.md", "beta");
+		expect(settings.notes["a.md"]).toMatchObject({
+			id: "a",
+			serverUpdatedAt: "T1",
+		});
+		expect(settings.notes["b.md"]).toMatchObject({
+			id: "b",
+			serverUpdatedAt: "T1",
+		});
+		expect(plugin.saveData).toHaveBeenCalledWith(settings);
+		expect(noticeCalls).toContainEqual(expect.stringContaining("Importadas: 2"));
+	});
+
+	test("path já existe localmente: ignora e Notice menciona ignoradas", async () => {
+		const existing = new TFile("foo.md", 1000);
+		const { plugin, vault } = makeFakePlugin({
+			vaultFiles: { "foo.md": existing },
+		});
+		const settings = makeSettings();
+		listNotes.mockResolvedValue([
+			{
+				id: "a",
+				path: "foo.md",
+				content: "x",
+				created_at: "T0",
+				updated_at: "T1",
+			},
+		]);
+
+		await importFromServer(plugin as never, settings);
+
+		expect(vault.create).not.toHaveBeenCalled();
+		expect(settings.notes["foo.md"]).toBeUndefined();
+		expect(plugin.saveData).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(expect.stringContaining("Importadas: 0"));
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("existiam localmente: 1"),
+		);
+	});
+
+	test("path com pasta inexistente: createFolder antes de create", async () => {
+		const { plugin, vault } = makeFakePlugin();
+		const settings = makeSettings();
+		listNotes.mockResolvedValue([
+			{
+				id: "x",
+				path: "pasta/sub/nota.md",
+				content: "z",
+				created_at: "T0",
+				updated_at: "T1",
+			},
+		]);
+
+		await importFromServer(plugin as never, settings);
+
+		expect(vault.createFolder).toHaveBeenCalledWith("pasta/sub");
+		expect(vault.create).toHaveBeenCalledWith("pasta/sub/nota.md", "z");
+	});
+
+	test("listNotes rejeita: Notice de erro e vault não tocado", async () => {
+		const { plugin, vault } = makeFakePlugin();
+		const settings = makeSettings();
+		listNotes.mockRejectedValue(
+			new MarkuppApiError("internal", "erro interno", 500),
+		);
+
+		await importFromServer(plugin as never, settings);
+
+		expect(vault.create).not.toHaveBeenCalled();
+		expect(plugin.saveData).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("Erro do servidor"),
+		);
+	});
+});

--- a/obsidian-plugin/src/commands/import.ts
+++ b/obsidian-plugin/src/commands/import.ts
@@ -1,0 +1,64 @@
+import { Notice, Plugin } from "obsidian";
+import { listNotes, MarkuppApiError } from "../api/client";
+import { MarkuppSettings } from "../settings";
+import { setNoteMeta } from "../storage/note-index";
+
+export async function importFromServer(
+	plugin: Plugin,
+	settings: MarkuppSettings,
+): Promise<void> {
+	let serverNotes;
+	try {
+		serverNotes = await listNotes(settings.backendUrl);
+	} catch (err) {
+		new Notice(buildErrorMessage(err, settings.backendUrl));
+		return;
+	}
+
+	let importadas = 0;
+	let ignoradas = 0;
+	let erros = 0;
+
+	for (const nota of serverNotes) {
+		try {
+			if (plugin.app.vault.getAbstractFileByPath(nota.path)) {
+				ignoradas++;
+				continue;
+			}
+
+			const lastSlash = nota.path.lastIndexOf("/");
+			if (lastSlash > 0) {
+				const folder = nota.path.slice(0, lastSlash);
+				if (!plugin.app.vault.getAbstractFileByPath(folder)) {
+					await plugin.app.vault.createFolder(folder);
+				}
+			}
+
+			const file = await plugin.app.vault.create(nota.path, nota.content);
+			setNoteMeta(settings, nota.path, {
+				id: nota.id,
+				serverUpdatedAt: nota.updated_at,
+				localMtimeAtSync: file.stat.mtime,
+			});
+			importadas++;
+		} catch {
+			erros++;
+		}
+	}
+
+	if (importadas > 0) {
+		await plugin.saveData(settings);
+	}
+
+	let msg = `Importadas: ${importadas}`;
+	if (ignoradas > 0) msg += `. Já existiam localmente: ${ignoradas}`;
+	if (erros > 0) msg += `. Erros: ${erros}`;
+	new Notice(msg);
+}
+
+function buildErrorMessage(err: unknown, backendUrl: string): string {
+	if (err instanceof MarkuppApiError) {
+		return `Erro do servidor (${err.status}): ${err.message}`;
+	}
+	return `Não foi possível conectar a ${backendUrl}. Verifique se o backend está rodando.`;
+}

--- a/obsidian-plugin/src/commands/import.ts
+++ b/obsidian-plugin/src/commands/import.ts
@@ -41,7 +41,8 @@ export async function importFromServer(
 				localMtimeAtSync: file.stat.mtime,
 			});
 			importadas++;
-		} catch {
+		} catch (err) {
+			console.error(`Falha ao importar ${nota.path}:`, err);
 			erros++;
 		}
 	}

--- a/obsidian-plugin/src/commands/sync-all.test.ts
+++ b/obsidian-plugin/src/commands/sync-all.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as client from "../api/client";
+import { MarkuppApiError } from "../api/client";
+import * as syncMod from "./sync";
+import type { MarkuppSettings, NoteMeta } from "../settings";
+import { makeFakePlugin } from "../__mocks__/fake-plugin";
+import {
+	clearNoticeCalls,
+	noticeCalls,
+	TFile,
+} from "../__mocks__/obsidian";
+import { syncAllNotes } from "./sync-all";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+vi.mock("../api/client", async () => {
+	const actual =
+		await vi.importActual<typeof import("../api/client")>("../api/client");
+	return {
+		...actual,
+		listNotes: vi.fn(),
+		createNote: vi.fn(),
+		updateNote: vi.fn(),
+		getNote: vi.fn(),
+	};
+});
+vi.mock("./sync", async () => {
+	const actual = await vi.importActual<typeof import("./sync")>("./sync");
+	return {
+		...actual,
+		syncOneFile: vi.fn(),
+	};
+});
+
+const listNotes = vi.mocked(client.listNotes);
+const syncOneFile = vi.mocked(syncMod.syncOneFile);
+
+beforeEach(() => {
+	listNotes.mockReset();
+	syncOneFile.mockReset();
+	clearNoticeCalls();
+});
+
+function makeSettings(
+	notes: Record<string, NoteMeta>,
+): MarkuppSettings {
+	return { backendUrl: "http://localhost:8080", notes };
+}
+
+describe("syncAllNotes", () => {
+	test("sem notas no mapping: Notice avisando, listNotes não é chamado", async () => {
+		const { plugin } = makeFakePlugin();
+		const settings = makeSettings({});
+
+		await syncAllNotes(plugin as never, settings);
+
+		expect(listNotes).not.toHaveBeenCalled();
+		expect(syncOneFile).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("Importar do servidor"),
+		);
+	});
+
+	test("listNotes rejeita: Notice de conexão", async () => {
+		const { plugin } = makeFakePlugin({
+			vaultFiles: { "a.md": new TFile("a.md", 1000) },
+		});
+		const settings = makeSettings({
+			"a.md": { id: "a", serverUpdatedAt: "T1", localMtimeAtSync: 1000 },
+		});
+		listNotes.mockRejectedValue(
+			new MarkuppApiError("internal", "erro", 500),
+		);
+
+		await syncAllNotes(plugin as never, settings);
+
+		expect(syncOneFile).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("Erro do servidor"),
+		);
+	});
+
+	test("2 notas no-op: contagens corretas, sem conflito nem erro", async () => {
+		const { plugin } = makeFakePlugin({
+			vaultFiles: {
+				"a.md": new TFile("a.md", 1000),
+				"b.md": new TFile("b.md", 1000),
+			},
+		});
+		const settings = makeSettings({
+			"a.md": { id: "a", serverUpdatedAt: "T1", localMtimeAtSync: 1000 },
+			"b.md": { id: "b", serverUpdatedAt: "T1", localMtimeAtSync: 1000 },
+		});
+		listNotes.mockResolvedValue([
+			{
+				id: "a",
+				path: "a.md",
+				content: "x",
+				created_at: "T0",
+				updated_at: "T1",
+			},
+			{
+				id: "b",
+				path: "b.md",
+				content: "y",
+				created_at: "T0",
+				updated_at: "T1",
+			},
+		]);
+		syncOneFile.mockResolvedValue("noop");
+
+		await syncAllNotes(plugin as never, settings);
+
+		expect(syncOneFile).toHaveBeenCalledTimes(2);
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("2 sem mudança"),
+		);
+		expect(noticeCalls).not.toContainEqual(
+			expect.stringContaining("conflito"),
+		);
+		expect(noticeCalls).not.toContainEqual(expect.stringContaining("erro"));
+	});
+
+	test("conflito: path aparece no Notice", async () => {
+		const { plugin } = makeFakePlugin({
+			vaultFiles: { "x.md": new TFile("x.md", 1000) },
+		});
+		const settings = makeSettings({
+			"x.md": { id: "x", serverUpdatedAt: "T1", localMtimeAtSync: 1000 },
+		});
+		listNotes.mockResolvedValue([
+			{
+				id: "x",
+				path: "x.md",
+				content: "z",
+				created_at: "T0",
+				updated_at: "T2",
+			},
+		]);
+		syncOneFile.mockResolvedValue("conflict");
+
+		await syncAllNotes(plugin as never, settings);
+
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("1 em conflito"),
+		);
+		expect(noticeCalls).toContainEqual(expect.stringContaining("x.md"));
+	});
+
+	test("meta órfã (id sumiu do servidor): meta limpa e contado como erro", async () => {
+		const { plugin } = makeFakePlugin({
+			vaultFiles: { "fantasma.md": new TFile("fantasma.md", 1000) },
+		});
+		const settings = makeSettings({
+			"fantasma.md": {
+				id: "ghost",
+				serverUpdatedAt: "T1",
+				localMtimeAtSync: 1000,
+			},
+		});
+		listNotes.mockResolvedValue([]);
+
+		await syncAllNotes(plugin as never, settings);
+
+		expect(syncOneFile).not.toHaveBeenCalled();
+		expect(settings.notes["fantasma.md"]).toBeUndefined();
+		expect(plugin.saveData).toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(expect.stringContaining("1 com erro"));
+	});
+});

--- a/obsidian-plugin/src/commands/sync-all.test.ts
+++ b/obsidian-plugin/src/commands/sync-all.test.ts
@@ -56,7 +56,7 @@ describe("syncAllNotes", () => {
 		expect(listNotes).not.toHaveBeenCalled();
 		expect(syncOneFile).not.toHaveBeenCalled();
 		expect(noticeCalls).toContainEqual(
-			expect.stringContaining("Importar do servidor"),
+			expect.stringContaining("Importe do servidor"),
 		);
 	});
 

--- a/obsidian-plugin/src/commands/sync-all.ts
+++ b/obsidian-plugin/src/commands/sync-all.ts
@@ -15,7 +15,7 @@ export async function syncAllNotes(
 	const paths = Object.keys(settings.notes);
 	if (paths.length === 0) {
 		new Notice(
-			"Nenhuma nota sincronizada localmente. Use 'Importar do servidor' para começar.",
+			"Nenhuma nota sincronizada localmente. Importe do servidor para começar.",
 		);
 		return;
 	}

--- a/obsidian-plugin/src/commands/sync-all.ts
+++ b/obsidian-plugin/src/commands/sync-all.ts
@@ -1,0 +1,85 @@
+import { Notice, Plugin, TFile } from "obsidian";
+import {
+	listNotes,
+	MarkuppApiError,
+	NoteResponse,
+} from "../api/client";
+import { MarkuppSettings } from "../settings";
+import { getNoteMeta, removeNoteMeta } from "../storage/note-index";
+import { syncOneFile } from "./sync";
+
+export async function syncAllNotes(
+	plugin: Plugin,
+	settings: MarkuppSettings,
+): Promise<void> {
+	const paths = Object.keys(settings.notes);
+	if (paths.length === 0) {
+		new Notice(
+			"Nenhuma nota sincronizada localmente. Use 'Importar do servidor' para começar.",
+		);
+		return;
+	}
+
+	let serverNotes: NoteResponse[];
+	try {
+		serverNotes = await listNotes(settings.backendUrl);
+	} catch (err) {
+		new Notice(connectionErrorMessage(err, settings.backendUrl));
+		return;
+	}
+
+	const serverById = new Map<string, NoteResponse>();
+	for (const n of serverNotes) serverById.set(n.id, n);
+
+	const counts = { noop: 0, pulled: 0, pushed: 0, conflict: 0, errors: 0 };
+	const conflitos: string[] = [];
+
+	for (const path of paths) {
+		const meta = getNoteMeta(settings, path);
+		if (!meta) continue;
+
+		const file = plugin.app.vault.getAbstractFileByPath(path);
+		if (!(file instanceof TFile)) continue;
+
+		const serverNote = serverById.get(meta.id);
+		if (!serverNote) {
+			removeNoteMeta(settings, path);
+			counts.errors++;
+			continue;
+		}
+
+		try {
+			const result = await syncOneFile(plugin, settings, file, meta, {
+				serverNote,
+			});
+			counts[result]++;
+			if (result === "conflict") conflitos.push(path);
+		} catch (err) {
+			if (
+				err instanceof MarkuppApiError &&
+				(err.code === "not_found" || err.code === "invalid_id")
+			) {
+				removeNoteMeta(settings, path);
+			}
+			counts.errors++;
+		}
+	}
+
+	await plugin.saveData(settings);
+
+	let msg = `Sincronização: ${counts.noop} sem mudança, ${counts.pulled} baixadas, ${counts.pushed} enviadas`;
+	if (counts.conflict > 0) {
+		const sample = conflitos.slice(0, 3).join(", ");
+		const more = conflitos.length > 3 ? "..." : "";
+		msg += `, ${counts.conflict} em conflito (${sample}${more})`;
+	}
+	if (counts.errors > 0) msg += `, ${counts.errors} com erro`;
+	new Notice(msg);
+}
+
+function connectionErrorMessage(err: unknown, backendUrl: string): string {
+	if (err instanceof MarkuppApiError) {
+		return `Erro do servidor (${err.status}): ${err.message}`;
+	}
+	return `Não foi possível conectar a ${backendUrl}. Verifique se o backend está rodando.`;
+}

--- a/obsidian-plugin/src/commands/sync.test.ts
+++ b/obsidian-plugin/src/commands/sync.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as client from "../api/client";
+import * as upload from "./upload";
+import type { MarkuppSettings, NoteMeta } from "../settings";
+import { makeFakePlugin } from "../__mocks__/fake-plugin";
+import { clearNoticeCalls, noticeCalls } from "../__mocks__/obsidian";
+import { syncActiveNote } from "./sync";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+vi.mock("../api/client", async () => {
+	const actual =
+		await vi.importActual<typeof import("../api/client")>("../api/client");
+	return {
+		...actual,
+		createNote: vi.fn(),
+		updateNote: vi.fn(),
+		getNote: vi.fn(),
+	};
+});
+vi.mock("./upload", () => ({
+	uploadActiveNote: vi.fn(),
+}));
+
+const getNote = vi.mocked(client.getNote);
+const updateNote = vi.mocked(client.updateNote);
+const uploadActiveNote = vi.mocked(upload.uploadActiveNote);
+
+beforeEach(() => {
+	getNote.mockReset();
+	updateNote.mockReset();
+	uploadActiveNote.mockReset();
+	clearNoticeCalls();
+});
+
+function makeSettings(notes: Record<string, NoteMeta> = {}): MarkuppSettings {
+	return { backendUrl: "http://localhost:8080", notes };
+}
+
+describe("syncActiveNote", () => {
+	test("sem meta: delega para uploadActiveNote", async () => {
+		const { plugin } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+		});
+		const settings = makeSettings();
+
+		await syncActiveNote(plugin as never, settings);
+
+		expect(uploadActiveNote).toHaveBeenCalledWith(plugin, settings);
+		expect(getNote).not.toHaveBeenCalled();
+	});
+
+	test("nada mudou: Notice 'já sincronizado', nenhuma escrita", async () => {
+		const { plugin, vault } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+		});
+		const settings = makeSettings({
+			"foo.md": { id: "id", serverUpdatedAt: "T1", localMtimeAtSync: 1700 },
+		});
+		getNote.mockResolvedValue({
+			id: "id",
+			path: "foo.md",
+			content: "x",
+			created_at: "T0",
+			updated_at: "T1",
+		});
+
+		await syncActiveNote(plugin as never, settings);
+
+		expect(vault.modify).not.toHaveBeenCalled();
+		expect(updateNote).not.toHaveBeenCalled();
+		expect(plugin.saveData).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("Já sincronizado"),
+		);
+	});
+
+	test("só servidor mudou: vault.modify + meta atualizada", async () => {
+		const { plugin, vault, file } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+		});
+		const settings = makeSettings({
+			"foo.md": { id: "id", serverUpdatedAt: "T1", localMtimeAtSync: 1700 },
+		});
+		getNote.mockResolvedValue({
+			id: "id",
+			path: "foo.md",
+			content: "novo do servidor",
+			created_at: "T0",
+			updated_at: "T2",
+		});
+
+		await syncActiveNote(plugin as never, settings);
+
+		expect(vault.modify).toHaveBeenCalledWith(file, "novo do servidor");
+		expect(updateNote).not.toHaveBeenCalled();
+		expect(settings.notes["foo.md"]).toEqual({
+			id: "id",
+			serverUpdatedAt: "T2",
+			localMtimeAtSync: file!.stat.mtime,
+		});
+	});
+
+	test("só local mudou: updateNote chamado + meta atualizada", async () => {
+		const { plugin, vault } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+			fileContent: "novo local",
+		});
+		const settings = makeSettings({
+			"foo.md": { id: "id", serverUpdatedAt: "T1", localMtimeAtSync: 1500 },
+		});
+		getNote.mockResolvedValue({
+			id: "id",
+			path: "foo.md",
+			content: "x",
+			created_at: "T0",
+			updated_at: "T1",
+		});
+		updateNote.mockResolvedValue({
+			id: "id",
+			path: "foo.md",
+			content: "novo local",
+			created_at: "T0",
+			updated_at: "T3",
+		});
+
+		await syncActiveNote(plugin as never, settings);
+
+		expect(updateNote).toHaveBeenCalledWith(
+			"http://localhost:8080",
+			"id",
+			"foo.md",
+			"novo local",
+		);
+		expect(vault.modify).not.toHaveBeenCalled();
+		expect(settings.notes["foo.md"]).toEqual({
+			id: "id",
+			serverUpdatedAt: "T3",
+			localMtimeAtSync: 1700,
+		});
+	});
+
+	test("conflito (ambos mudaram): Notice de conflito, nada escrito", async () => {
+		const { plugin, vault } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+		});
+		const settings = makeSettings({
+			"foo.md": { id: "id", serverUpdatedAt: "T1", localMtimeAtSync: 1500 },
+		});
+		getNote.mockResolvedValue({
+			id: "id",
+			path: "foo.md",
+			content: "x",
+			created_at: "T0",
+			updated_at: "T2",
+		});
+
+		await syncActiveNote(plugin as never, settings);
+
+		expect(vault.modify).not.toHaveBeenCalled();
+		expect(updateNote).not.toHaveBeenCalled();
+		expect(plugin.saveData).not.toHaveBeenCalled();
+		expect(settings.notes["foo.md"]).toEqual({
+			id: "id",
+			serverUpdatedAt: "T1",
+			localMtimeAtSync: 1500,
+		});
+		expect(noticeCalls).toContainEqual(expect.stringContaining("Conflito"));
+	});
+});

--- a/obsidian-plugin/src/commands/sync.ts
+++ b/obsidian-plugin/src/commands/sync.ts
@@ -1,0 +1,101 @@
+import { MarkdownView, Notice, Plugin } from "obsidian";
+import { getNote, MarkuppApiError, updateNote } from "../api/client";
+import { MarkuppSettings } from "../settings";
+import {
+	getNoteMeta,
+	removeNoteMeta,
+	setNoteMeta,
+} from "../storage/note-index";
+import { uploadActiveNote } from "./upload";
+
+export async function syncActiveNote(
+	plugin: Plugin,
+	settings: MarkuppSettings,
+): Promise<void> {
+	const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+	if (!view || !view.file) {
+		new Notice("Nenhuma nota ativa");
+		return;
+	}
+
+	const file = view.file;
+	const path = file.path;
+	const meta = getNoteMeta(settings, path);
+
+	if (!meta) {
+		return uploadActiveNote(plugin, settings);
+	}
+
+	try {
+		const serverNote = await getNote(settings.backendUrl, meta.id);
+
+		const serverChanged = serverNote.updated_at !== meta.serverUpdatedAt;
+		const localChanged = file.stat.mtime !== meta.localMtimeAtSync;
+
+		if (!serverChanged && !localChanged) {
+			new Notice("Já sincronizado.");
+			return;
+		}
+
+		if (serverChanged && !localChanged) {
+			await plugin.app.vault.modify(file, serverNote.content);
+			setNoteMeta(settings, path, {
+				id: serverNote.id,
+				serverUpdatedAt: serverNote.updated_at,
+				localMtimeAtSync: file.stat.mtime,
+			});
+			await plugin.saveData(settings);
+			new Notice(`Atualização do servidor baixada: ${path}`);
+			return;
+		}
+
+		if (!serverChanged && localChanged) {
+			const content = await plugin.app.vault.read(file);
+			const note = await updateNote(
+				settings.backendUrl,
+				meta.id,
+				path,
+				content,
+			);
+			setNoteMeta(settings, path, {
+				id: note.id,
+				serverUpdatedAt: note.updated_at,
+				localMtimeAtSync: file.stat.mtime,
+			});
+			await plugin.saveData(settings);
+			new Notice(`Alterações locais enviadas: ${path}`);
+			return;
+		}
+
+		new Notice(
+			"Conflito: nota mudou nos dois lados desde a última sync. Use 'Subir' ou 'Baixar' para escolher.",
+		);
+	} catch (err) {
+		if (
+			err instanceof MarkuppApiError &&
+			(err.code === "not_found" || err.code === "invalid_id")
+		) {
+			removeNoteMeta(settings, path);
+			await plugin.saveData(settings);
+		}
+		new Notice(buildErrorMessage(err, settings.backendUrl));
+	}
+}
+
+function buildErrorMessage(err: unknown, backendUrl: string): string {
+	if (err instanceof MarkuppApiError) {
+		switch (err.code) {
+			case "not_found":
+				return "Servidor não tem mais essa nota — referência local removida. Use Subir para recriar.";
+			case "invalid_id":
+				return "Id inválido no servidor — referência local removida.";
+			case "invalid_path":
+				return `Caminho inválido: ${err.message}`;
+			case "invalid_content":
+				return `Conteúdo inválido: ${err.message}`;
+			default:
+				return `Erro do servidor (${err.status}): ${err.message}`;
+		}
+	}
+	return `Não foi possível conectar a ${backendUrl}. Verifique se o backend está rodando.`;
+}

--- a/obsidian-plugin/src/commands/sync.ts
+++ b/obsidian-plugin/src/commands/sync.ts
@@ -1,12 +1,67 @@
-import { MarkdownView, Notice, Plugin } from "obsidian";
-import { getNote, MarkuppApiError, updateNote } from "../api/client";
-import { MarkuppSettings } from "../settings";
+import { MarkdownView, Notice, Plugin, TFile } from "obsidian";
+import {
+	getNote,
+	MarkuppApiError,
+	NoteResponse,
+	updateNote,
+} from "../api/client";
+import { MarkuppSettings, NoteMeta } from "../settings";
 import {
 	getNoteMeta,
 	removeNoteMeta,
 	setNoteMeta,
 } from "../storage/note-index";
 import { uploadActiveNote } from "./upload";
+
+export type SyncResult = "noop" | "pulled" | "pushed" | "conflict";
+
+export type SyncOptions = {
+	serverNote?: NoteResponse;
+};
+
+export async function syncOneFile(
+	plugin: Plugin,
+	settings: MarkuppSettings,
+	file: TFile,
+	meta: NoteMeta,
+	options: SyncOptions = {},
+): Promise<SyncResult> {
+	const path = file.path;
+	const serverNote =
+		options.serverNote ?? (await getNote(settings.backendUrl, meta.id));
+
+	const serverChanged = serverNote.updated_at !== meta.serverUpdatedAt;
+	const localChanged = file.stat.mtime !== meta.localMtimeAtSync;
+
+	if (!serverChanged && !localChanged) {
+		return "noop";
+	}
+
+	if (serverChanged && !localChanged) {
+		await plugin.app.vault.modify(file, serverNote.content);
+		setNoteMeta(settings, path, {
+			id: serverNote.id,
+			serverUpdatedAt: serverNote.updated_at,
+			localMtimeAtSync: file.stat.mtime,
+		});
+		await plugin.saveData(settings);
+		return "pulled";
+	}
+
+	if (!serverChanged && localChanged) {
+		const content = await plugin.app.vault.read(file);
+		const note = await updateNote(settings.backendUrl, meta.id, path, content);
+		setNoteMeta(settings, path, {
+			id: note.id,
+			serverUpdatedAt: note.updated_at,
+			localMtimeAtSync: file.stat.mtime,
+		});
+		await plugin.saveData(settings);
+		return "pushed";
+	}
+
+	return "conflict";
+}
 
 export async function syncActiveNote(
 	plugin: Plugin,
@@ -27,49 +82,8 @@ export async function syncActiveNote(
 	}
 
 	try {
-		const serverNote = await getNote(settings.backendUrl, meta.id);
-
-		const serverChanged = serverNote.updated_at !== meta.serverUpdatedAt;
-		const localChanged = file.stat.mtime !== meta.localMtimeAtSync;
-
-		if (!serverChanged && !localChanged) {
-			new Notice("Já sincronizado.");
-			return;
-		}
-
-		if (serverChanged && !localChanged) {
-			await plugin.app.vault.modify(file, serverNote.content);
-			setNoteMeta(settings, path, {
-				id: serverNote.id,
-				serverUpdatedAt: serverNote.updated_at,
-				localMtimeAtSync: file.stat.mtime,
-			});
-			await plugin.saveData(settings);
-			new Notice(`Atualização do servidor baixada: ${path}`);
-			return;
-		}
-
-		if (!serverChanged && localChanged) {
-			const content = await plugin.app.vault.read(file);
-			const note = await updateNote(
-				settings.backendUrl,
-				meta.id,
-				path,
-				content,
-			);
-			setNoteMeta(settings, path, {
-				id: note.id,
-				serverUpdatedAt: note.updated_at,
-				localMtimeAtSync: file.stat.mtime,
-			});
-			await plugin.saveData(settings);
-			new Notice(`Alterações locais enviadas: ${path}`);
-			return;
-		}
-
-		new Notice(
-			"Conflito: nota mudou nos dois lados desde a última sync. Use 'Subir' ou 'Baixar' para escolher.",
-		);
+		const result = await syncOneFile(plugin, settings, file, meta);
+		new Notice(messageFor(result, path));
 	} catch (err) {
 		if (
 			err instanceof MarkuppApiError &&
@@ -79,6 +93,19 @@ export async function syncActiveNote(
 			await plugin.saveData(settings);
 		}
 		new Notice(buildErrorMessage(err, settings.backendUrl));
+	}
+}
+
+function messageFor(result: SyncResult, path: string): string {
+	switch (result) {
+		case "noop":
+			return "Já sincronizado.";
+		case "pulled":
+			return `Atualização do servidor baixada: ${path}`;
+		case "pushed":
+			return `Alterações locais enviadas: ${path}`;
+		case "conflict":
+			return "Conflito: nota mudou nos dois lados desde a última sync. Use 'Subir' ou 'Baixar' para escolher.";
 	}
 }
 

--- a/obsidian-plugin/src/commands/upload.test.ts
+++ b/obsidian-plugin/src/commands/upload.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as client from "../api/client";
+import { MarkuppApiError } from "../api/client";
+import type { MarkuppSettings, NoteMeta } from "../settings";
+import { makeFakePlugin } from "../__mocks__/fake-plugin";
+import { clearNoticeCalls, noticeCalls } from "../__mocks__/obsidian";
+import { uploadActiveNote } from "./upload";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+vi.mock("../api/client", async () => {
+	const actual =
+		await vi.importActual<typeof import("../api/client")>("../api/client");
+	return {
+		...actual,
+		createNote: vi.fn(),
+		updateNote: vi.fn(),
+		getNote: vi.fn(),
+	};
+});
+
+const createNote = vi.mocked(client.createNote);
+const updateNote = vi.mocked(client.updateNote);
+
+beforeEach(() => {
+	createNote.mockReset();
+	updateNote.mockReset();
+	clearNoticeCalls();
+});
+
+function makeSettings(notes: Record<string, NoteMeta> = {}): MarkuppSettings {
+	return { backendUrl: "http://localhost:8080", notes };
+}
+
+const baseNoteResponse = {
+	id: "srv-id",
+	path: "foo.md",
+	content: "hi",
+	created_at: "2026-05-09T10:00:00Z",
+	updated_at: "2026-05-09T10:00:00Z",
+};
+
+describe("uploadActiveNote", () => {
+	test("sem meta local: cria, salva NoteMeta e mostra Notice de sucesso", async () => {
+		const { plugin } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+			fileContent: "hi",
+		});
+		const settings = makeSettings();
+		createNote.mockResolvedValue(baseNoteResponse);
+
+		await uploadActiveNote(plugin as never, settings);
+
+		expect(createNote).toHaveBeenCalledWith(
+			"http://localhost:8080",
+			"foo.md",
+			"hi",
+		);
+		expect(updateNote).not.toHaveBeenCalled();
+		expect(settings.notes["foo.md"]).toEqual({
+			id: "srv-id",
+			serverUpdatedAt: "2026-05-09T10:00:00Z",
+			localMtimeAtSync: 1700,
+		});
+		expect(plugin.saveData).toHaveBeenCalledWith(settings);
+		expect(noticeCalls).toContainEqual(expect.stringContaining("enviada"));
+	});
+
+	test("com meta local: chama updateNote e não chama createNote", async () => {
+		const { plugin } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+			fileContent: "hi",
+		});
+		const settings = makeSettings({
+			"foo.md": {
+				id: "old-id",
+				serverUpdatedAt: "old",
+				localMtimeAtSync: 1500,
+			},
+		});
+		updateNote.mockResolvedValue({
+			...baseNoteResponse,
+			id: "old-id",
+			updated_at: "new",
+		});
+
+		await uploadActiveNote(plugin as never, settings);
+
+		expect(updateNote).toHaveBeenCalledWith(
+			"http://localhost:8080",
+			"old-id",
+			"foo.md",
+			"hi",
+		);
+		expect(createNote).not.toHaveBeenCalled();
+		expect(settings.notes["foo.md"]).toEqual({
+			id: "old-id",
+			serverUpdatedAt: "new",
+			localMtimeAtSync: 1700,
+		});
+	});
+
+	test("not_found em update: limpa meta local e mostra Notice", async () => {
+		const { plugin } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+			fileContent: "hi",
+		});
+		const settings = makeSettings({
+			"foo.md": { id: "ghost", serverUpdatedAt: "x", localMtimeAtSync: 1500 },
+		});
+		updateNote.mockRejectedValue(
+			new MarkuppApiError("not_found", "nota não encontrada", 404),
+		);
+
+		await uploadActiveNote(plugin as never, settings);
+
+		expect(settings.notes["foo.md"]).toBeUndefined();
+		expect(plugin.saveData).toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(expect.stringContaining("Subir"));
+	});
+
+	test("duplicate_path em create: Notice mas NÃO salva meta", async () => {
+		const { plugin } = makeFakePlugin({
+			file: { path: "foo.md", stat: { mtime: 1700 } },
+			fileContent: "hi",
+		});
+		const settings = makeSettings();
+		createNote.mockRejectedValue(
+			new MarkuppApiError("duplicate_path", "já existe", 409),
+		);
+
+		await uploadActiveNote(plugin as never, settings);
+
+		expect(settings.notes["foo.md"]).toBeUndefined();
+		expect(plugin.saveData).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(expect.stringContaining("Já existe"));
+	});
+
+	test("sem nota ativa: Notice e nenhuma chamada de API", async () => {
+		const { plugin } = makeFakePlugin({ file: null });
+		const settings = makeSettings();
+
+		await uploadActiveNote(plugin as never, settings);
+
+		expect(createNote).not.toHaveBeenCalled();
+		expect(updateNote).not.toHaveBeenCalled();
+		expect(noticeCalls).toContainEqual(
+			expect.stringContaining("Nenhuma nota ativa"),
+		);
+	});
+});

--- a/obsidian-plugin/src/commands/upload.ts
+++ b/obsidian-plugin/src/commands/upload.ts
@@ -1,6 +1,15 @@
 import { MarkdownView, Notice, Plugin } from "obsidian";
-import { createNote, MarkuppApiError } from "../api/client";
+import {
+	createNote,
+	MarkuppApiError,
+	updateNote,
+} from "../api/client";
 import { MarkuppSettings } from "../settings";
+import {
+	getNoteMeta,
+	removeNoteMeta,
+	setNoteMeta,
+} from "../storage/note-index";
 
 export async function uploadActiveNote(
 	plugin: Plugin,
@@ -14,12 +23,29 @@ export async function uploadActiveNote(
 
 	const file = view.file;
 	const path = file.path;
+	const meta = getNoteMeta(settings, path);
 
 	try {
 		const content = await plugin.app.vault.read(file);
-		await createNote(settings.backendUrl, path, content);
+		const note = meta
+			? await updateNote(settings.backendUrl, meta.id, path, content)
+			: await createNote(settings.backendUrl, path, content);
+
+		setNoteMeta(settings, path, {
+			id: note.id,
+			serverUpdatedAt: note.updated_at,
+			localMtimeAtSync: file.stat.mtime,
+		});
+		await plugin.saveData(settings);
 		new Notice(`Nota enviada: ${path}`);
 	} catch (err) {
+		if (
+			err instanceof MarkuppApiError &&
+			(err.code === "not_found" || err.code === "invalid_id")
+		) {
+			removeNoteMeta(settings, path);
+			await plugin.saveData(settings);
+		}
 		new Notice(buildErrorMessage(err, settings.backendUrl));
 	}
 }
@@ -27,12 +53,16 @@ export async function uploadActiveNote(
 function buildErrorMessage(err: unknown, backendUrl: string): string {
 	if (err instanceof MarkuppApiError) {
 		switch (err.code) {
+			case "not_found":
+				return "Servidor não tem mais essa nota — clique Subir de novo para recriar.";
+			case "invalid_id":
+				return "Id inválido no servidor — referência local removida.";
 			case "invalid_path":
 				return `Caminho inválido: ${err.message}`;
 			case "invalid_content":
 				return `Conteúdo inválido: ${err.message}`;
 			case "duplicate_path":
-				return "Nota já existe no servidor. Atualização ainda não suportada.";
+				return "Já existe nota com esse caminho no servidor.";
 			default:
 				return `Erro do servidor (${err.status}): ${err.message}`;
 		}

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -3,6 +3,7 @@ import { DEFAULT_SETTINGS, MarkuppSettings, MarkuppSettingTab } from "./settings
 import { downloadActiveNote } from "./commands/download";
 import { importFromServer } from "./commands/import";
 import { syncActiveNote } from "./commands/sync";
+import { syncAllNotes } from "./commands/sync-all";
 import { uploadActiveNote } from "./commands/upload";
 import { getNoteMeta, removeNoteMeta, renameNote } from "./storage/note-index";
 
@@ -16,6 +17,7 @@ export default class MarkuppPlugin extends Plugin {
 		const upload = () => uploadActiveNote(this, this.settings);
 		const download = () => downloadActiveNote(this, this.settings);
 		const importAll = () => importFromServer(this, this.settings);
+		const syncAll = () => syncAllNotes(this, this.settings);
 
 		this.addRibbonIcon("arrow-big-up-dash", "Markupp", (evt) => {
 			const menu = new Menu();
@@ -34,6 +36,12 @@ export default class MarkuppPlugin extends Plugin {
 					.setTitle("Importar do servidor")
 					.setIcon("download-cloud")
 					.onClick(importAll),
+			);
+			menu.addItem((item) =>
+				item
+					.setTitle("Sincronizar tudo")
+					.setIcon("refresh-ccw")
+					.onClick(syncAll),
 			);
 			menu.showAtMouseEvent(evt);
 		});
@@ -57,6 +65,11 @@ export default class MarkuppPlugin extends Plugin {
 			id: "markupp-import",
 			name: "Markupp: Importar do servidor",
 			callback: importAll,
+		});
+		this.addCommand({
+			id: "markupp-sync-all",
+			name: "Markupp: Sincronizar tudo",
+			callback: syncAll,
 		});
 
 		this.addSettingTab(new MarkuppSettingTab(this.app, this));

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,6 +1,7 @@
-import { Plugin } from "obsidian";
+import { Plugin, TAbstractFile } from "obsidian";
 import { DEFAULT_SETTINGS, MarkuppSettings, MarkuppSettingTab } from "./settings";
 import { uploadActiveNote } from "./commands/upload-active-note";
+import { getNoteMeta, removeNoteMeta, renameNote } from "./storage/note-index";
 
 export default class MarkuppPlugin extends Plugin {
 	settings!: MarkuppSettings;
@@ -20,6 +21,21 @@ export default class MarkuppPlugin extends Plugin {
 
 		this.addSettingTab(new MarkuppSettingTab(this.app, this));
 
+		this.registerEvent(
+			this.app.vault.on("rename", async (file: TAbstractFile, oldPath: string) => {
+				if (!getNoteMeta(this.settings, oldPath)) return;
+				renameNote(this.settings, oldPath, file.path);
+				await this.saveSettings();
+			}),
+		);
+
+		this.registerEvent(
+			this.app.vault.on("delete", async (file: TAbstractFile) => {
+				if (!getNoteMeta(this.settings, file.path)) return;
+				removeNoteMeta(this.settings, file.path);
+				await this.saveSettings();
+			}),
+		);
 	}
 
 	onunload() {}

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,5 +1,7 @@
-import { Plugin, TAbstractFile } from "obsidian";
+import { Menu, Plugin, TAbstractFile } from "obsidian";
 import { DEFAULT_SETTINGS, MarkuppSettings, MarkuppSettingTab } from "./settings";
+import { downloadActiveNote } from "./commands/download";
+import { syncActiveNote } from "./commands/sync";
 import { uploadActiveNote } from "./commands/upload";
 import { getNoteMeta, removeNoteMeta, renameNote } from "./storage/note-index";
 
@@ -9,14 +11,38 @@ export default class MarkuppPlugin extends Plugin {
 	async onload() {
 		await this.loadSettings();
 
+		const sync = () => syncActiveNote(this, this.settings);
 		const upload = () => uploadActiveNote(this, this.settings);
+		const download = () => downloadActiveNote(this, this.settings);
 
-		this.addRibbonIcon("arrow-big-up-dash", "Subir nota ativa", upload);
+		this.addRibbonIcon("arrow-big-up-dash", "Markupp", (evt) => {
+			const menu = new Menu();
+			menu.addItem((item) =>
+				item.setTitle("Sincronizar").setIcon("refresh-cw").onClick(sync),
+			);
+			menu.addItem((item) =>
+				item.setTitle("Subir").setIcon("upload").onClick(upload),
+			);
+			menu.addItem((item) =>
+				item.setTitle("Baixar").setIcon("download").onClick(download),
+			);
+			menu.showAtMouseEvent(evt);
+		});
 
 		this.addCommand({
-			id: "upload-active-note",
-			name: "Subir nota ativa",
+			id: "markupp-sync",
+			name: "Markupp: Sincronizar nota ativa",
+			callback: sync,
+		});
+		this.addCommand({
+			id: "markupp-upload",
+			name: "Markupp: Subir nota ativa",
 			callback: upload,
+		});
+		this.addCommand({
+			id: "markupp-download",
+			name: "Markupp: Baixar nota ativa",
+			callback: download,
 		});
 
 		this.addSettingTab(new MarkuppSettingTab(this.app, this));

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,6 +1,7 @@
 import { Menu, Plugin, TAbstractFile } from "obsidian";
 import { DEFAULT_SETTINGS, MarkuppSettings, MarkuppSettingTab } from "./settings";
 import { downloadActiveNote } from "./commands/download";
+import { importFromServer } from "./commands/import";
 import { syncActiveNote } from "./commands/sync";
 import { uploadActiveNote } from "./commands/upload";
 import { getNoteMeta, removeNoteMeta, renameNote } from "./storage/note-index";
@@ -14,6 +15,7 @@ export default class MarkuppPlugin extends Plugin {
 		const sync = () => syncActiveNote(this, this.settings);
 		const upload = () => uploadActiveNote(this, this.settings);
 		const download = () => downloadActiveNote(this, this.settings);
+		const importAll = () => importFromServer(this, this.settings);
 
 		this.addRibbonIcon("arrow-big-up-dash", "Markupp", (evt) => {
 			const menu = new Menu();
@@ -25,6 +27,13 @@ export default class MarkuppPlugin extends Plugin {
 			);
 			menu.addItem((item) =>
 				item.setTitle("Baixar").setIcon("download").onClick(download),
+			);
+			menu.addSeparator();
+			menu.addItem((item) =>
+				item
+					.setTitle("Importar do servidor")
+					.setIcon("download-cloud")
+					.onClick(importAll),
 			);
 			menu.showAtMouseEvent(evt);
 		});
@@ -43,6 +52,11 @@ export default class MarkuppPlugin extends Plugin {
 			id: "markupp-download",
 			name: "Markupp: Baixar nota ativa",
 			callback: download,
+		});
+		this.addCommand({
+			id: "markupp-import",
+			name: "Markupp: Importar do servidor",
+			callback: importAll,
 		});
 
 		this.addSettingTab(new MarkuppSettingTab(this.app, this));

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,6 +1,6 @@
 import { Plugin, TAbstractFile } from "obsidian";
 import { DEFAULT_SETTINGS, MarkuppSettings, MarkuppSettingTab } from "./settings";
-import { uploadActiveNote } from "./commands/upload-active-note";
+import { uploadActiveNote } from "./commands/upload";
 import { getNoteMeta, removeNoteMeta, renameNote } from "./storage/note-index";
 
 export default class MarkuppPlugin extends Plugin {

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -48,27 +48,27 @@ export default class MarkuppPlugin extends Plugin {
 
 		this.addCommand({
 			id: "markupp-sync",
-			name: "Markupp: Sincronizar nota ativa",
+			name: "Sincronizar nota ativa",
 			callback: sync,
 		});
 		this.addCommand({
 			id: "markupp-upload",
-			name: "Markupp: Subir nota ativa",
+			name: "Subir nota ativa",
 			callback: upload,
 		});
 		this.addCommand({
 			id: "markupp-download",
-			name: "Markupp: Baixar nota ativa",
+			name: "Baixar nota ativa",
 			callback: download,
 		});
 		this.addCommand({
 			id: "markupp-import",
-			name: "Markupp: Importar do servidor",
+			name: "Importar do servidor",
 			callback: importAll,
 		});
 		this.addCommand({
 			id: "markupp-sync-all",
-			name: "Markupp: Sincronizar tudo",
+			name: "Sincronizar tudo",
 			callback: syncAll,
 		});
 

--- a/obsidian-plugin/src/settings.ts
+++ b/obsidian-plugin/src/settings.ts
@@ -1,12 +1,20 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import MarkuppPlugin from "./main";
 
+export type NoteMeta = {
+	id: string;
+	serverUpdatedAt: string;
+	localMtimeAtSync: number;
+};
+
 export interface MarkuppSettings {
 	backendUrl: string;
+	notes: Record<string, NoteMeta>;
 }
 
 export const DEFAULT_SETTINGS: MarkuppSettings = {
 	backendUrl: "http://localhost:8080",
+	notes: {},
 };
 
 export class MarkuppSettingTab extends PluginSettingTab {

--- a/obsidian-plugin/src/storage/note-index.test.ts
+++ b/obsidian-plugin/src/storage/note-index.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import {
+	getNoteMeta,
+	removeNoteMeta,
+	renameNote,
+	setNoteMeta,
+} from "./note-index";
+import type { MarkuppSettings, NoteMeta } from "../settings";
+
+function emptySettings(): MarkuppSettings {
+	return { backendUrl: "http://localhost:8080", notes: {} };
+}
+
+const meta: NoteMeta = {
+	id: "abc",
+	serverUpdatedAt: "2026-05-09T00:00:00Z",
+	localMtimeAtSync: 1234567890,
+};
+
+describe("note-index", () => {
+	test("setNoteMeta + getNoteMeta round-trip", () => {
+		const settings = emptySettings();
+		setNoteMeta(settings, "foo.md", meta);
+
+		expect(getNoteMeta(settings, "foo.md")).toEqual(meta);
+	});
+
+	test("getNoteMeta retorna undefined para chave inexistente", () => {
+		expect(getNoteMeta(emptySettings(), "x.md")).toBeUndefined();
+	});
+
+	test("removeNoteMeta apaga entrada existente", () => {
+		const settings = emptySettings();
+		setNoteMeta(settings, "foo.md", meta);
+
+		removeNoteMeta(settings, "foo.md");
+
+		expect(getNoteMeta(settings, "foo.md")).toBeUndefined();
+	});
+
+	test("removeNoteMeta em chave inexistente é no-op", () => {
+		const settings = emptySettings();
+
+		expect(() => removeNoteMeta(settings, "fantasma.md")).not.toThrow();
+		expect(settings.notes).toEqual({});
+	});
+
+	test("renameNote move entrada e remove a chave antiga", () => {
+		const settings = emptySettings();
+		setNoteMeta(settings, "old.md", meta);
+
+		renameNote(settings, "old.md", "new.md");
+
+		expect(getNoteMeta(settings, "old.md")).toBeUndefined();
+		expect(getNoteMeta(settings, "new.md")).toEqual(meta);
+	});
+
+	test("renameNote é no-op se origem não existe", () => {
+		const settings = emptySettings();
+
+		renameNote(settings, "fantasma.md", "novo.md");
+
+		expect(settings.notes).toEqual({});
+	});
+});

--- a/obsidian-plugin/src/storage/note-index.ts
+++ b/obsidian-plugin/src/storage/note-index.ts
@@ -1,0 +1,34 @@
+import type { MarkuppSettings, NoteMeta } from "../settings";
+
+export function getNoteMeta(
+	settings: MarkuppSettings,
+	path: string,
+): NoteMeta | undefined {
+	return settings.notes[path];
+}
+
+export function setNoteMeta(
+	settings: MarkuppSettings,
+	path: string,
+	meta: NoteMeta,
+): void {
+	settings.notes[path] = meta;
+}
+
+export function removeNoteMeta(
+	settings: MarkuppSettings,
+	path: string,
+): void {
+	delete settings.notes[path];
+}
+
+export function renameNote(
+	settings: MarkuppSettings,
+	oldPath: string,
+	newPath: string,
+): void {
+	const meta = settings.notes[oldPath];
+	if (!meta) return;
+	settings.notes[newPath] = meta;
+	delete settings.notes[oldPath];
+}


### PR DESCRIPTION
## O que mudou
  - 3 comandos por nota ativa: Sincronizar, Subir, Baixar
  - 2 comandos em lote: Importar do servidor e Sincronizar tudo
  - Sincronizar detecta quando os dois lados mudaram desde a última sync e nesse caso não escreve em nenhum lugar, usuário escolhe: Subir ou Baixar manualmente
  - Mapping path: id + timestamps em data.json do plugin, com listeners de vault.rename e vault.delete mantendo coerente
  - Backend: rota GET /notes que devolve a lista (com content)

## Por quê
- O plugin antes só criava nota (POST). Editar a mesma duas vezes dava duplicate_path, e quem abrisse um vault vazio não via nada do  servidor. Um botão "atualizar inteligente" que sobrescreve sozinho seria ruim quando duas pessoas mexem na mesma nota, então daí os três comandos explícitos e o Sincronizar tratando conflito como pergunta pro usuário, não como decisão automática.

## Como testar
- Subir o backend:
  
```bash
docker compose up
```
- Compilar o plugin:
```bash  
cd obsidian-plugin
npm install
npm run dev
```
- No Obsidian: Settings > Community plugins > ativar o Markupp Plugin > configurar a URL (http://localhost:8080).

### Cenários:

  1. Criar do zero: nota nova > ribbon Markupp > Subir > Notice "Nota enviada".
  2. Sincronizar sem mudanças: clicar Sincronizar logo em seguida > "Já sincronizado".
  3. Editar local + Sincronizar: alterar a nota no Obsidian, salvar, Sincronizar > "Alterações locais enviadas".
  4. Editar servidor + Sincronizar: alterar via curl PUT direto, depois Sincronizar > "Atualização do servidor baixada".
  5. Conflito: editar local e via curl na sequência sem sincronizar; Sincronizar > Notice de conflito, nada é tocado. Resolver com Subir ou Baixar.
  6. Vault novo: apagar .obsidian/plugins/markupp/data.json e os .md do vault. Ribbon > Importar do servidor > arquivos voltam.
  7. Sincronizar tudo: editar várias notas, rodar Markupp: Sincronizar tudo no command palette > Notice consolidada com contagens (e até 3 paths em conflito se houver).
  8. Rename: renomear arquivo no Obsidian → próximo Sincronizar funciona com novo path, sem duplicate_path.

 ### Testes automatizados:
```bash  
cd backend && go test ./... -race -count=1
cd obsidian-plugin && npm run test
```
## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [ ] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
Use rótulos: [Risco], [Manutenção], [Teste]

- [Risco] Conflito edição-cruzada não é resolvido automaticamente: quando local e servidor divergiram desde a última sync, Sincronizar mostra Notice e não toca em nenhum dos dois lados. Foi escolha deliberada pra não perder trabalho silenciosamente 
 - [Manutenção] "Importar do servidor" só cria arquivos para paths que não existem localmente. Se o data.json for perdido mas o vault ainda tiver as notas, esses arquivos não ganham vínculo automaticamente. vincular meta órfã exige comparar conteúdo byte-a-byte e ficou como issue futura.
 - [Teste] 44 testes vitest no plugin (cliente HTTP, mapping local e os 5 comandos) + testes Go no backend cobrindo repository (DB SQLite em memória), service (fake repo), handler (fake service) e integration (servidor + DB reais). CI roda os dois.