### PR TITLE
feat: added openapi yaml file

### DIFF
--- a/backend/internal/notes/notes.go
+++ b/backend/internal/notes/notes.go
@@ -105,8 +105,8 @@ func (s *Service) Update(ctx context.Context, id, path, content string) (Note, e
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {
-	if strings.TrimSpace(id) == "" {
-		return ErrNotFound
+	if err := s.validateId(ctx, id); err != nil {
+		return err
 	}
 	if err := s.repo.Delete(ctx, id); err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -118,7 +118,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 }
 
 func (s *Service) validateId(ctx context.Context, id string) error {
-	if id == "" {
+	if strings.TrimSpace(id) == "" {
 		return ErrInvalidId
 	}
 	return nil

--- a/backend/internal/notes/service_test.go
+++ b/backend/internal/notes/service_test.go
@@ -228,14 +228,14 @@ func TestUpdate_CaminhoFeliz_RetornaNotaAtualizada(t *testing.T) {
 	assert.False(t, repo.updateArgs.updatedAt.IsZero())
 }
 
-func TestDelete_IDVazio_RetornaErrNotFoundSemChamarRepo(t *testing.T) {
+func TestDelete_IDVazio_RetornaErrInvalidIdSemChamarRepo(t *testing.T) {
 	repo := &fakeRepo{}
 	svc := newServiceForTest(repo)
 
 	err := svc.Delete(context.Background(), "")
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, notes.ErrNotFound))
+	assert.True(t, errors.Is(err, notes.ErrInvalidId))
 	assert.False(t, repo.deleteCalled)
 }
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,210 @@
+openapi: 3.0.3
+info:
+  title: Markupp Backend API
+  description: API REST para gerenciamento de notas do projeto Markupp.
+  version: 0.1.0
+servers:
+  - url: http://localhost:8080
+    description: Servidor local padrão
+paths:
+  /notes:
+    post:
+      summary: Cria uma nova nota
+      description: Cria uma nota com caminho e conteúdo fornecidos.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NoteRequest'
+      responses:
+        '201':
+          description: Nota criada com sucesso
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoteResponse'
+        '400':
+          description: Requisição inválida ou dados de nota inválidos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Caminho de nota duplicado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Erro interno do servidor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /notes/{id}:
+    get:
+      summary: Recupera uma nota por ID
+      description: Retorna a nota correspondente ao identificador fornecido.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Identificador único da nota
+      responses:
+        '200':
+          description: Nota encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoteResponse'
+        '400':
+          description: ID inválido
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Nota não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Erro interno do servidor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      summary: Atualiza uma nota existente
+      description: Atualiza o caminho e conteúdo de uma nota existente.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Identificador único da nota
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NoteRequest'
+      responses:
+        '200':
+          description: Nota atualizada com sucesso
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoteResponse'
+        '400':
+          description: Requisição inválida ou dados de nota inválidos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Nota não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Caminho de nota duplicado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Erro interno do servidor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: Exclui uma nota
+      description: Remove a nota identificada pelo ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Identificador único da nota
+      responses:
+        '204':
+          description: Nota excluída com sucesso
+        '400':
+          description: ID inválido
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Nota não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Erro interno do servidor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    NoteRequest:
+      type: object
+      required:
+        - path
+        - content
+      properties:
+        path:
+          type: string
+          description: Caminho/identificador do arquivo de nota
+          example: "notas/meeting.md"
+        content:
+          type: string
+          description: Conteúdo da nota
+          example: "# Reunião\n- Tarefa 1\n- Tarefa 2"
+    NoteResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identificador único da nota
+          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        path:
+          type: string
+          description: Caminho/identificador do arquivo de nota
+          example: "notas/meeting.md"
+        content:
+          type: string
+          description: Conteúdo da nota
+          example: "# Reunião\n- Tarefa 1\n- Tarefa 2"
+        created_at:
+          type: string
+          format: date-time
+          description: Data de criação da nota
+          example: "2026-05-14T12:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: Data da última atualização da nota
+          example: "2026-05-14T12:00:00Z"
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Código de erro
+          example: "invalid_request"
+        message:
+          type: string
+          description: Mensagem de erro legível
+          example: "JSON inválido"


### PR DESCRIPTION
## O que mudou
- Adicionado o documento OpenAPI em openapi.yaml para descrever os endpoints /notes e /notes/{id}.

## Por quê
- Para oferecer uma documentação formal da API e facilitar integração com clientes ou ferramentas automáticas.
- Closes #48 

## Como testar
- Revise openapi.yaml e confirme se os schemas e respostas refletem corretamente o código do backend.

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [ ] Casos limite considerados (ex.: vazio, 0, erro)
- [ ] Evidência de teste (manual ou automatizado)

## Comentários técnicos
- [Manutenção] A OpenAPI adicionada padroniza a documentação do backend e facilita manutenção futura do contrato entre frontend e backend.

---

- Closes #13