### PR TITLE
feat: configuração do servidor via arquivo JSON

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,26 @@
+# Markupp backend
+
+Servidor REST do Markupp em Go.
+
+## Build
+
+```sh
+go build ./cmd/markupp
+```
+
+## Execução
+
+```sh
+./markupp
+```
+
+## Configuração
+
+O servidor lê a configuração de um arquivo JSON. O caminho é resolvido nesta ordem:
+
+1. Variável de ambiente `MARKUPP_CONFIG_PATH`
+2. Fallback `./config.json` no diretório de trabalho
+
+Se o arquivo não existir, os defaults são aplicados silenciosamente. Chaves ausentes no arquivo preservam o default correspondente.
+
+Exemplo em `config.example.json`.

--- a/backend/cmd/markupp/main.go
+++ b/backend/cmd/markupp/main.go
@@ -4,22 +4,24 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/ifsc-ES2/projeto-markupp/backend/internal/api"
+	"github.com/ifsc-ES2/projeto-markupp/backend/internal/config"
 	"github.com/ifsc-ES2/projeto-markupp/backend/internal/notes"
 	"github.com/ifsc-ES2/projeto-markupp/backend/internal/storage"
-)
-
-const (
-	serverPort  = "8080"
-	dbPath      = "./markupp.db"
-	maxNoteSize = 50 * 1024 * 1024
 )
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
-	db, err := storage.OpenDB(dbPath)
+	cfg, err := config.Load()
+	if err != nil {
+		logger.Error("carregar config", "err", err)
+		os.Exit(1)
+	}
+
+	db, err := storage.OpenDB(cfg.DBPath)
 	if err != nil {
 		logger.Error("abrir db", "err", err)
 		os.Exit(1)
@@ -32,10 +34,10 @@ func main() {
 	}
 
 	repo := storage.NewSqliteNotesRepository(db)
-	svc := notes.NewService(repo, maxNoteSize)
+	svc := notes.NewService(repo, cfg.MaxNoteSize)
 	router := api.NewRouter(svc)
 
-	addr := ":" + serverPort
+	addr := ":" + strconv.Itoa(cfg.Port)
 	logger.Info("servidor subindo", "addr", addr)
 	if err := http.ListenAndServe(addr, router); err != nil {
 		logger.Error("servidor", "err", err)

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -1,0 +1,5 @@
+{
+  "port": 8080,
+  "db_path": "./markupp.db",
+  "max_note_size": 52428800
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+)
+
+const (
+	envVarName  = "MARKUPP_CONFIG_PATH"
+	defaultPath = "./config.json"
+)
+
+type Config struct {
+	Port        int    `json:"port"`
+	DBPath      string `json:"db_path"`
+	MaxNoteSize int    `json:"max_note_size"`
+}
+
+func Default() Config {
+	return Config{
+		Port:        8080,
+		DBPath:      "./markupp.db",
+		MaxNoteSize: 50 * 1024 * 1024,
+	}
+}
+
+func Load() (Config, error) {
+	path := os.Getenv(envVarName)
+	if path == "" {
+		path = defaultPath
+	}
+
+	cfg := Default()
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return cfg, nil
+	}
+	if err != nil {
+		return cfg, err
+	}
+
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -15,7 +15,7 @@ const (
 type Config struct {
 	Port        int    `json:"port"`
 	DBPath      string `json:"db_path"`
-	MaxNoteSize int    `json:"max_note_size"`
+	MaxNoteSize int64  `json:"max_note_size"`
 }
 
 func Default() Config {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -16,7 +16,7 @@ func TestDefault_RetornaValoresPadrao(t *testing.T) {
 
 	assert.Equal(t, 8080, cfg.Port)
 	assert.Equal(t, "./markupp.db", cfg.DBPath)
-	assert.Equal(t, 50*1024*1024, cfg.MaxNoteSize)
+	assert.Equal(t, int64(50*1024*1024), cfg.MaxNoteSize)
 }
 
 func TestLoad_SemEnvVarSemArquivo_RetornaDefaults(t *testing.T) {
@@ -51,7 +51,7 @@ func TestLoad_FallbackConfigJsonNoCwd_QuandoEnvVarVazia(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 9090, cfg.Port)
 	assert.Equal(t, "/data/markupp.db", cfg.DBPath)
-	assert.Equal(t, 1024, cfg.MaxNoteSize)
+	assert.Equal(t, int64(1024), cfg.MaxNoteSize)
 }
 
 func TestLoad_ArquivoCompleto_LeTodosOsCampos(t *testing.T) {
@@ -65,7 +65,7 @@ func TestLoad_ArquivoCompleto_LeTodosOsCampos(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 9090, cfg.Port)
 	assert.Equal(t, "/data/markupp.db", cfg.DBPath)
-	assert.Equal(t, 1024, cfg.MaxNoteSize)
+	assert.Equal(t, int64(1024), cfg.MaxNoteSize)
 }
 
 func TestLoad_ArquivoParcial_PreservaDefaultsDasChavesAusentes(t *testing.T) {
@@ -79,7 +79,7 @@ func TestLoad_ArquivoParcial_PreservaDefaultsDasChavesAusentes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 9090, cfg.Port)
 	assert.Equal(t, "./markupp.db", cfg.DBPath)
-	assert.Equal(t, 50*1024*1024, cfg.MaxNoteSize)
+	assert.Equal(t, int64(50*1024*1024), cfg.MaxNoteSize)
 }
 
 func TestLoad_JsonInvalido_RetornaErro(t *testing.T) {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,94 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ifsc-ES2/projeto-markupp/backend/internal/config"
+)
+
+func TestDefault_RetornaValoresPadrao(t *testing.T) {
+	cfg := config.Default()
+
+	assert.Equal(t, 8080, cfg.Port)
+	assert.Equal(t, "./markupp.db", cfg.DBPath)
+	assert.Equal(t, 50*1024*1024, cfg.MaxNoteSize)
+}
+
+func TestLoad_SemEnvVarSemArquivo_RetornaDefaults(t *testing.T) {
+	t.Setenv("MARKUPP_CONFIG_PATH", "")
+	t.Chdir(t.TempDir())
+
+	cfg, err := config.Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, config.Default(), cfg)
+}
+
+func TestLoad_EnvVarApontaPathInexistente_RetornaDefaults(t *testing.T) {
+	t.Setenv("MARKUPP_CONFIG_PATH", filepath.Join(t.TempDir(), "nao-existe.json"))
+
+	cfg, err := config.Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, config.Default(), cfg)
+}
+
+func TestLoad_FallbackConfigJsonNoCwd_QuandoEnvVarVazia(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"port": 9090, "db_path": "/data/markupp.db", "max_note_size": 1024}`), 0o600))
+
+	t.Setenv("MARKUPP_CONFIG_PATH", "")
+	t.Chdir(dir)
+
+	cfg, err := config.Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, "/data/markupp.db", cfg.DBPath)
+	assert.Equal(t, 1024, cfg.MaxNoteSize)
+}
+
+func TestLoad_ArquivoCompleto_LeTodosOsCampos(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"port": 9090, "db_path": "/data/markupp.db", "max_note_size": 1024}`), 0o600))
+
+	t.Setenv("MARKUPP_CONFIG_PATH", path)
+
+	cfg, err := config.Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, "/data/markupp.db", cfg.DBPath)
+	assert.Equal(t, 1024, cfg.MaxNoteSize)
+}
+
+func TestLoad_ArquivoParcial_PreservaDefaultsDasChavesAusentes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"port": 9090}`), 0o600))
+
+	t.Setenv("MARKUPP_CONFIG_PATH", path)
+
+	cfg, err := config.Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, "./markupp.db", cfg.DBPath)
+	assert.Equal(t, 50*1024*1024, cfg.MaxNoteSize)
+}
+
+func TestLoad_JsonInvalido_RetornaErro(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{port: invalido`), 0o600))
+
+	t.Setenv("MARKUPP_CONFIG_PATH", path)
+
+	_, err := config.Load()
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
## O que mudou
- Pacote `internal/config` com `Load()` e `Default()`
- `main.go` lê config via `MARKUPP_CONFIG_PATH` (fallback `./config.json`)
- `MaxNoteSize` tipado como `int64`
- `backend/README.md` e `backend/config.example.json`

## Por quê
- Fecha #44: substituir constantes hardcoded por arquivo JSON com defaults

## Como testar
- `cd backend && go test ./... -race`
- Subir sem arquivo: defaults aplicados
- Subir com `MARKUPP_CONFIG_PATH` apontando para JSON parcial: chaves ausentes preservam defaults
- Subir com JSON inválido: servidor falha no boot

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (arquivo ausente, JSON parcial, JSON inválido)
- [x] Evidência de teste (7 testes unitários no pacote config)

## Comentários técnicos (mínimo 3)
- [Risco] arquivo ausente é silencioso por design; operador precisa ler o README para saber que defaults entraram
- [Manutenção] adicionar nova chave requer apenas estender `Config`, atualizar `Default()` e `config.example.json`
- [Teste] pré-popular `cfg` com `Default()` antes de `json.Unmarshal` cobre "chave faltando preserva default" sem código extra, validado em `TestLoad_ArquivoParcial_PreservaDefaultsDasChavesAusentes`

Closes #44