### PR TITLE
chore: remove exigência de comentários técnicos no template de PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,3 @@
 - [ ] PR pequeno e focado
 - [ ] Casos limite considerados (ex.: vazio, 0, erro)
 - [ ] Evidência de teste (manual ou automatizado)
-## Comentários técnicos (mínimo 3)
-Use rótulos: [Risco], [Manutenção], [Teste]


### PR DESCRIPTION
## O que mudou
- Remove a seção `Comentários técnicos (mínimo 3)` do `.github/PULL_REQUEST_TEMPLATE.md`.

## Por quê
- A exigência de no mínimo 3 comentários técnicos com rótulos `[Risco]`, `[Manutenção]`, `[Teste]` não está agregando valor proporcional ao atrito que gera. Auto-review e descrição clara já cobrem o essencial.

## Como testar
- Abrir um novo PR e confirmar que o template carregado não pede mais a seção de comentários técnicos.

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)