### PR TITLE
Feature/search route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ DOCKER_COMPOSE=docker compose
 
 all: compose-env compose-config docker-up docker-test docker-down
 
+test: docker-test
+
 # Testa o módulo de banco de dados do servidor dentro de um contêiner Docker
 test-db-config:
 	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) run --rm markupp sh -c "cd $(MARKUPP_WORKDIR) && go test $(DB_CONFIG_PKG)"
@@ -17,9 +19,9 @@ compose-config:
 
 # Configura variáveis de ambiente no ambiente do Compose
 compose-env:
-    @if [ ! -f .env ]; then \
-      printf 'MARKUPP_PORT=8080\nDATA_VOLUME=markupp_data\nGO_MOD_CACHE=go_mod_cache\n' > .env; \
-    fi
+	@if [ ! -f .env ]; then \
+		printf 'MARKUPP_PORT=8080\nDATA_VOLUME=markupp_data\nGO_MOD_CACHE=go_mod_cache\n' > .env; \
+	fi
 	@echo "Criando arquivo .env com valores padrão..."
 	@printf 'MARKUPP_PORT=8080\nDATA_VOLUME=markupp_data\nGO_MOD_CACHE=go_mod_cache\n' > .env
 	@echo ".env criado/atualizado com sucesso."

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ compose-env:
 	@if [ ! -f .env ]; then \
 		printf 'MARKUPP_PORT=8080\nDATA_VOLUME=markupp_data\nGO_MOD_CACHE=go_mod_cache\n' > .env; \
 	fi
-	@echo "Criando arquivo .env com valores padrão..."
-	@printf 'MARKUPP_PORT=8080\nDATA_VOLUME=markupp_data\nGO_MOD_CACHE=go_mod_cache\n' > .env
 	@echo ".env criado/atualizado com sucesso."
 
 # Sobe o container Docker do servidor em modo destacado

--- a/markupp/internal/api/notes_handler.go
+++ b/markupp/internal/api/notes_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -19,6 +20,7 @@ type NoteService interface {
 	Delete(ctx context.Context, id string) error
 	GetNoteById(ctx context.Context, id string) (notes.Note, error)
 	ListNotes(ctx context.Context) ([]notes.Note, error)
+	SearchNotes(ctx context.Context, query string, offset, limit int) ([]notes.SearchResult, error)
 }
 
 type notesHandler struct {
@@ -104,6 +106,40 @@ func (h *notesHandler) list(w http.ResponseWriter, r *http.Request) {
 		out = append(out, toResponse(n))
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *notesHandler) search(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		writeError(w, "invalid_request", "query string 'query' é obrigatória", http.StatusBadRequest)
+		return
+	}
+
+	offset, err := parseQueryInt(r.URL.Query().Get("offset"), 0)
+	if err != nil {
+		writeError(w, "invalid_request", "offset deve ser um inteiro", http.StatusBadRequest)
+		return
+	}
+
+	limit, err := parseQueryInt(r.URL.Query().Get("limit"), 10)
+	if err != nil {
+		writeError(w, "invalid_request", "limit deve ser um inteiro", http.StatusBadRequest)
+		return
+	}
+
+	results, err := h.svc.SearchNotes(r.Context(), query, offset, limit)
+	if err != nil {
+		writeDomainError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, results)
+}
+
+func parseQueryInt(value string, defaultValue int) (int, error) {
+	if value == "" {
+		return defaultValue, nil
+	}
+	return strconv.Atoi(value)
 }
 
 func (h *notesHandler) delete(w http.ResponseWriter, r *http.Request) {

--- a/markupp/internal/api/notes_handler.go
+++ b/markupp/internal/api/notes_handler.go
@@ -40,6 +40,12 @@ type errorResponse struct {
 	Message string `json:"message"`
 }
 
+const (
+	maxOffset = 10_000
+	maxLimit  = 100
+	minLimit  = 1
+)
+
 func toResponse(n notes.Note) noteResponse {
 	return noteResponse{
 		ID:        n.ID,
@@ -127,6 +133,9 @@ func (h *notesHandler) search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	offset = clamp(offset, 0, maxOffset)
+	limit = clamp(limit, minLimit, maxLimit)
+
 	results, err := h.svc.SearchNotes(r.Context(), query, offset, limit)
 	if err != nil {
 		writeDomainError(w, err)
@@ -140,6 +149,16 @@ func parseQueryInt(value string, defaultValue int) (int, error) {
 		return defaultValue, nil
 	}
 	return strconv.Atoi(value)
+}
+
+func clamp(v, min, max int) int {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
 }
 
 func (h *notesHandler) delete(w http.ResponseWriter, r *http.Request) {

--- a/markupp/internal/api/notes_handler_test.go
+++ b/markupp/internal/api/notes_handler_test.go
@@ -39,6 +39,15 @@ type fakeService struct {
 	listResult []notes.Note
 	listErr    error
 	listCalled bool
+
+	searchResult []notes.SearchResult
+	searchErr    error
+	searchArgs   struct {
+		query  string
+		offset int
+		limit  int
+		called bool
+	}
 }
 
 func (f *fakeService) Create(ctx context.Context, path, content string) (notes.Note, error) {
@@ -66,6 +75,14 @@ func (f *fakeService) GetNoteById(ctx context.Context, id string) (notes.Note, e
 func (f *fakeService) ListNotes(ctx context.Context) ([]notes.Note, error) {
 	f.listCalled = true
 	return f.listResult, f.listErr
+}
+
+func (f *fakeService) SearchNotes(ctx context.Context, query string, offset, limit int) ([]notes.SearchResult, error) {
+	f.searchArgs.called = true
+	f.searchArgs.query = query
+	f.searchArgs.offset = offset
+	f.searchArgs.limit = limit
+	return f.searchResult, f.searchErr
 }
 
 func doPost(t *testing.T, svc api.NoteService, body string) *httptest.ResponseRecorder {
@@ -319,6 +336,10 @@ func (s *stubRepository) ListNotes(ctx context.Context) ([]notes.Note, error) {
 	return s.listResult, s.listErr
 }
 
+func (s *stubRepository) SearchNotes(ctx context.Context, query string, offset, limit int32) ([]notes.SearchResult, error) {
+	return nil, nil
+}
+
 func TestGetNotes_IDNaoEncontrado_ComServiceReal_Retorna404(t *testing.T) {
 	repo := &stubRepository{getError: sql.ErrNoRows}
 	svc := notes.NewService(repo, 1000)
@@ -409,4 +430,57 @@ func TestListNotes_ServiceRetornaErro_Retorna500(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, "internal", resp["error"])
+}
+
+func TestSearchNotes_QueryValido_Retorna200(t *testing.T) {
+	now := time.Now()
+	svc := &fakeService{searchResult: []notes.SearchResult{
+		{ID: "id-1", Path: "a.md", UpdatedAt: now},
+		{ID: "id-2", Path: "b.md", UpdatedAt: now},
+	}}
+
+	router := api.NewRouter(svc)
+	req := httptest.NewRequest(http.MethodGet, "/notes/search?query=go&offset=1&limit=2", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Len(t, resp, 2)
+	assert.Equal(t, "id-1", resp[0]["id"])
+	assert.Equal(t, "a.md", resp[0]["path"])
+	assert.Equal(t, "id-2", resp[1]["id"])
+	assert.Equal(t, "b.md", resp[1]["path"])
+	assert.True(t, svc.searchArgs.called)
+	assert.Equal(t, "go", svc.searchArgs.query)
+	assert.Equal(t, 1, svc.searchArgs.offset)
+	assert.Equal(t, 2, svc.searchArgs.limit)
+}
+
+func TestSearchNotes_QueryObrigatoria_Retorna400(t *testing.T) {
+	svc := &fakeService{}
+	router := api.NewRouter(svc)
+	req := httptest.NewRequest(http.MethodGet, "/notes/search", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "invalid_request", resp["error"])
+}
+
+func TestSearchNotes_OffsetInvalido_Retorna400(t *testing.T) {
+	svc := &fakeService{}
+	router := api.NewRouter(svc)
+	req := httptest.NewRequest(http.MethodGet, "/notes/search?query=go&offset=abc", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "invalid_request", resp["error"])
 }

--- a/markupp/internal/api/router.go
+++ b/markupp/internal/api/router.go
@@ -13,6 +13,7 @@ func NewRouter(svc NoteService) chi.Router {
 	h := &notesHandler{svc: svc}
 	r.Post("/notes", h.create)
 	r.Get("/notes", h.list)
+	r.Get("/notes/search", h.search)
 	r.Get("/notes/{id}", h.get)
 	r.Put("/notes/{id}", h.update)
 	r.Delete("/notes/{id}", h.delete)

--- a/markupp/internal/notes/notes.go
+++ b/markupp/internal/notes/notes.go
@@ -18,6 +18,12 @@ type Note struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
+ 
+type SearchResult struct {
+	ID        string    `json:"id"`
+	Path      string    `json:"path"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
 
 type Repository interface {
 	Save(ctx context.Context, note Note) error
@@ -25,6 +31,7 @@ type Repository interface {
 	Delete(ctx context.Context, id string) error
 	GetNoteByID(ctx context.Context, id string) (Note, error)
 	ListNotes(ctx context.Context) ([]Note, error)
+	SearchNotes(ctx context.Context, query string, offset, limit int32) ([]SearchResult, error)
 }
 
 var (
@@ -148,4 +155,24 @@ func (s *Service) validateContent(content string) error {
 		return ErrInvalidContent
 	}
 	return nil
+}
+
+func (s *Service) Search(ctx context.Context, query string, offset, limit int) ([]SearchResult, error) {
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	searchQuery := "%" + query + "%"
+	results, err := s.repo.SearchNotes(ctx, searchQuery, int32(offset), int32(limit))
+	if err != nil {
+		return nil, fmt.Errorf("buscar notas: %w", err)
+	}
+	return results, nil
+}
+
+func (s *Service) SearchNotes(ctx context.Context, query string, offset, limit int) ([]SearchResult, error) {
+	return s.Search(ctx, query, offset, limit)
 }

--- a/markupp/internal/notes/notes.go
+++ b/markupp/internal/notes/notes.go
@@ -157,7 +157,7 @@ func (s *Service) validateContent(content string) error {
 	return nil
 }
 
-func (s *Service) Search(ctx context.Context, query string, offset, limit int) ([]SearchResult, error) {
+func (s *Service) SearchNotes(ctx context.Context, query string, offset, limit int) ([]SearchResult, error) {
 	if offset < 0 {
 		offset = 0
 	}
@@ -171,8 +171,4 @@ func (s *Service) Search(ctx context.Context, query string, offset, limit int) (
 		return nil, fmt.Errorf("buscar notas: %w", err)
 	}
 	return results, nil
-}
-
-func (s *Service) SearchNotes(ctx context.Context, query string, offset, limit int) ([]SearchResult, error) {
-	return s.Search(ctx, query, offset, limit)
 }

--- a/markupp/internal/notes/notes.go
+++ b/markupp/internal/notes/notes.go
@@ -18,7 +18,7 @@ type Note struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
- 
+
 type SearchResult struct {
 	ID        string    `json:"id"`
 	Path      string    `json:"path"`

--- a/markupp/internal/notes/service_test.go
+++ b/markupp/internal/notes/service_test.go
@@ -361,7 +361,7 @@ func TestSearch_RepoRetornaErro_Propagado(t *testing.T) {
 	repo := &fakeRepo{searchErr: errors.New("erro ao buscar")}
 	svc := newServiceForTest(repo)
 
-	_, err := svc.Search(context.Background(), "golang", 0, 10)
+	_, err := svc.SearchNotes(context.Background(), "golang", 0, 10)
 
 	require.Error(t, err)
 	assert.True(t, repo.searchArgs.called)
@@ -371,7 +371,7 @@ func TestSearch_SemResultados_RetornaSliceVazio(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
-	results, err := svc.Search(context.Background(), "golang", 0, 10)
+	results, err := svc.SearchNotes(context.Background(), "golang", 0, 10)
 
 	require.NoError(t, err)
 	assert.Empty(t, results)
@@ -385,7 +385,7 @@ func TestSearch_ComResultados_RetornaSomenteIdPathUpdatedAt(t *testing.T) {
 	}}
 	svc := newServiceForTest(repo)
 
-	results, err := svc.Search(context.Background(), "golang", 0, 10)
+	results, err := svc.SearchNotes(context.Background(), "golang", 0, 10)
 
 	require.NoError(t, err)
 	require.Len(t, results, 2)
@@ -405,7 +405,7 @@ func TestSearch_PaginacaoComOffset_PassaParametrosCorretosAoRepo(t *testing.T) {
 	}}
 	svc := newServiceForTest(repo)
 
-	results, err := svc.Search(context.Background(), "golang", 1, 2)
+	results, err := svc.SearchNotes(context.Background(), "golang", 1, 2)
 
 	require.NoError(t, err)
 	require.Len(t, results, 2)
@@ -422,7 +422,7 @@ func TestSearch_LimitZero_UsaPadraoDeZ(t *testing.T) {
 	repo := &fakeRepo{searchResult: make([]notes.SearchResult, 10)}
 	svc := newServiceForTest(repo)
 
-	_, err := svc.Search(context.Background(), "golang", 0, 0)
+	_, err := svc.SearchNotes(context.Background(), "golang", 0, 0)
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(10), repo.searchArgs.limit)
@@ -432,7 +432,7 @@ func TestSearch_LimitNegativo_UsaPadraoDeZ(t *testing.T) {
 	repo := &fakeRepo{searchResult: make([]notes.SearchResult, 10)}
 	svc := newServiceForTest(repo)
 
-	_, err := svc.Search(context.Background(), "golang", 0, -5)
+	_, err := svc.SearchNotes(context.Background(), "golang", 0, -5)
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(10), repo.searchArgs.limit)
@@ -442,7 +442,7 @@ func TestSearch_OffsetNegativo_UsaZero(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
-	_, err := svc.Search(context.Background(), "golang", -10, 5)
+	_, err := svc.SearchNotes(context.Background(), "golang", -10, 5)
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), repo.searchArgs.offset)
@@ -452,7 +452,7 @@ func TestSearch_AdicionaWildcardsNaQuery(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
-	_, err := svc.Search(context.Background(), "test", 0, 10)
+	_, err := svc.SearchNotes(context.Background(), "test", 0, 10)
 	require.NoError(t, err)
 
 	assert.Equal(t, "%test%", repo.searchArgs.query)
@@ -462,7 +462,7 @@ func TestSearch_QueryVazioComWildcards(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
-	_, err := svc.Search(context.Background(), "", 0, 10)
+	_, err := svc.SearchNotes(context.Background(), "", 0, 10)
 	require.NoError(t, err)
 
 	assert.Equal(t, "%%", repo.searchArgs.query)

--- a/markupp/internal/notes/service_test.go
+++ b/markupp/internal/notes/service_test.go
@@ -452,7 +452,8 @@ func TestSearch_AdicionaWildcardsNaQuery(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
-	svc.Search(context.Background(), "test", 0, 10)
+	_, err := svc.Search(context.Background(), "test", 0, 10)
+	require.NoError(t, err)
 
 	assert.Equal(t, "%test%", repo.searchArgs.query)
 }
@@ -461,7 +462,8 @@ func TestSearch_QueryVazioComWildcards(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
-	svc.Search(context.Background(), "", 0, 10)
+	_, err := svc.Search(context.Background(), "", 0, 10)
+	require.NoError(t, err)
 
 	assert.Equal(t, "%%", repo.searchArgs.query)
 }

--- a/markupp/internal/notes/service_test.go
+++ b/markupp/internal/notes/service_test.go
@@ -41,6 +41,15 @@ type fakeRepo struct {
 	listResult []notes.Note
 	listErr    error
 	listCalled bool
+
+	searchResult []notes.SearchResult
+	searchErr    error
+	searchArgs   struct {
+		query  string
+		offset int32
+		limit  int32
+		called bool
+	}
 }
 
 func (f *fakeRepo) Save(ctx context.Context, n notes.Note) error {
@@ -71,6 +80,14 @@ func (f *fakeRepo) GetNoteByID(ctx context.Context, id string) (notes.Note, erro
 func (f *fakeRepo) ListNotes(ctx context.Context) ([]notes.Note, error) {
 	f.listCalled = true
 	return f.listResult, f.listErr
+}
+
+func (f *fakeRepo) SearchNotes(ctx context.Context, query string, offset, limit int32) ([]notes.SearchResult, error) {
+	f.searchArgs.called = true
+	f.searchArgs.query = query
+	f.searchArgs.offset = offset
+	f.searchArgs.limit = limit
+	return f.searchResult, f.searchErr
 }
 
 func newServiceForTest(repo notes.Repository) *notes.Service {
@@ -338,4 +355,113 @@ func TestListNotes_DBVazio_RetornaSliceVazio(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, got)
+}
+
+func TestSearch_RepoRetornaErro_Propagado(t *testing.T) {
+	repo := &fakeRepo{searchErr: errors.New("erro ao buscar")}
+	svc := newServiceForTest(repo)
+
+	_, err := svc.Search(context.Background(), "golang", 0, 10)
+
+	require.Error(t, err)
+	assert.True(t, repo.searchArgs.called)
+}
+
+func TestSearch_SemResultados_RetornaSliceVazio(t *testing.T) {
+	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
+	svc := newServiceForTest(repo)
+
+	results, err := svc.Search(context.Background(), "golang", 0, 10)
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestSearch_ComResultados_RetornaSomenteIdPathUpdatedAt(t *testing.T) {
+	now := time.Date(2026, 5, 25, 10, 0, 0, 0, time.UTC)
+	repo := &fakeRepo{searchResult: []notes.SearchResult{
+		{ID: "id-1", Path: "golang.md", UpdatedAt: now},
+		{ID: "id-2", Path: "tips.md", UpdatedAt: now},
+	}}
+	svc := newServiceForTest(repo)
+
+	results, err := svc.Search(context.Background(), "golang", 0, 10)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "id-1", results[0].ID)
+	assert.Equal(t, "golang.md", results[0].Path)
+	assert.Equal(t, now, results[0].UpdatedAt)
+	assert.Equal(t, "id-2", results[1].ID)
+	assert.Equal(t, "tips.md", results[1].Path)
+	assert.Equal(t, now, results[1].UpdatedAt)
+}
+
+func TestSearch_PaginacaoComOffset_PassaParametrosCorretosAoRepo(t *testing.T) {
+	now := time.Now()
+	repo := &fakeRepo{searchResult: []notes.SearchResult{
+		{ID: "id-2", Path: "b.md", UpdatedAt: now},
+		{ID: "id-3", Path: "c.md", UpdatedAt: now},
+	}}
+	svc := newServiceForTest(repo)
+
+	results, err := svc.Search(context.Background(), "golang", 1, 2)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "id-2", results[0].ID)
+	assert.Equal(t, "id-3", results[1].ID)
+	// Valida que os parâmetros foram passados corretamente (com wildcards)
+	assert.True(t, repo.searchArgs.called)
+	assert.Equal(t, "%golang%", repo.searchArgs.query)
+	assert.Equal(t, int32(1), repo.searchArgs.offset)
+	assert.Equal(t, int32(2), repo.searchArgs.limit)
+}
+
+func TestSearch_LimitZero_UsaPadraoDeZ(t *testing.T) {
+	repo := &fakeRepo{searchResult: make([]notes.SearchResult, 10)}
+	svc := newServiceForTest(repo)
+
+	_, err := svc.Search(context.Background(), "golang", 0, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(10), repo.searchArgs.limit)
+}
+
+func TestSearch_LimitNegativo_UsaPadraoDeZ(t *testing.T) {
+	repo := &fakeRepo{searchResult: make([]notes.SearchResult, 10)}
+	svc := newServiceForTest(repo)
+
+	_, err := svc.Search(context.Background(), "golang", 0, -5)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(10), repo.searchArgs.limit)
+}
+
+func TestSearch_OffsetNegativo_UsaZero(t *testing.T) {
+	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
+	svc := newServiceForTest(repo)
+
+	_, err := svc.Search(context.Background(), "golang", -10, 5)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), repo.searchArgs.offset)
+}
+
+func TestSearch_AdicionaWildcardsNaQuery(t *testing.T) {
+	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
+	svc := newServiceForTest(repo)
+
+	svc.Search(context.Background(), "test", 0, 10)
+
+	assert.Equal(t, "%test%", repo.searchArgs.query)
+}
+
+func TestSearch_QueryVazioComWildcards(t *testing.T) {
+	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
+	svc := newServiceForTest(repo)
+
+	svc.Search(context.Background(), "", 0, 10)
+
+	assert.Equal(t, "%%", repo.searchArgs.query)
 }

--- a/markupp/internal/storage/gen/notes.sql.go
+++ b/markupp/internal/storage/gen/notes.sql.go
@@ -74,7 +74,7 @@ func (q *Queries) ListNotes(ctx context.Context) ([]Note, error) {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Note
+	items := []Note{}
 	for rows.Next() {
 		var i Note
 		if err := rows.Scan(
@@ -99,7 +99,7 @@ func (q *Queries) ListNotes(ctx context.Context) ([]Note, error) {
 
 const searchNotes = `-- name: SearchNotes :many
 SELECT id, path, updated_at FROM notes
-WHERE content GLOB ?
+WHERE content LIKE ?
 ORDER BY updated_at DESC
 LIMIT ? OFFSET ?
 `

--- a/markupp/internal/storage/gen/notes.sql.go
+++ b/markupp/internal/storage/gen/notes.sql.go
@@ -74,7 +74,7 @@ func (q *Queries) ListNotes(ctx context.Context) ([]Note, error) {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Note{}
+	var items []Note
 	for rows.Next() {
 		var i Note
 		if err := rows.Scan(
@@ -84,6 +84,48 @@ func (q *Queries) ListNotes(ctx context.Context) ([]Note, error) {
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const searchNotes = `-- name: SearchNotes :many
+SELECT id, path, updated_at FROM notes
+WHERE content GLOB ?
+ORDER BY updated_at DESC
+LIMIT ? OFFSET ?
+`
+
+type SearchNotesParams struct {
+	Content string
+	Limit   int64
+	Offset  int64
+}
+
+type SearchNotesRow struct {
+	ID        string
+	Path      string
+	UpdatedAt time.Time
+}
+
+func (q *Queries) SearchNotes(ctx context.Context, arg SearchNotesParams) ([]SearchNotesRow, error) {
+	rows, err := q.db.QueryContext(ctx, searchNotes, arg.Content, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SearchNotesRow
+	for rows.Next() {
+		var i SearchNotesRow
+		if err := rows.Scan(&i.ID, &i.Path, &i.UpdatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/markupp/internal/storage/notes.go
+++ b/markupp/internal/storage/notes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"strings"
 	"time"
 
 	sqlite "modernc.org/sqlite"
@@ -91,8 +90,6 @@ func (r *SqliteNotesRepository) GetNoteByID(ctx context.Context, id string) (not
 }
 
 func (r *SqliteNotesRepository) SearchNotes(ctx context.Context, query string, offset, limit int32) ([]notes.SearchResult, error) {
-	query = strings.ReplaceAll(query, "%", "*")
-	query = strings.ReplaceAll(query, "_", "?")
 	rows, err := r.q.SearchNotes(ctx, gen.SearchNotesParams{
 		Content: query,
 		Limit:   int64(limit),

--- a/markupp/internal/storage/notes.go
+++ b/markupp/internal/storage/notes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"time"
 
 	sqlite "modernc.org/sqlite"
@@ -87,6 +88,28 @@ func (r *SqliteNotesRepository) GetNoteByID(ctx context.Context, id string) (not
 		CreatedAt: row.CreatedAt,
 		UpdatedAt: row.UpdatedAt,
 	}, nil
+}
+
+func (r *SqliteNotesRepository) SearchNotes(ctx context.Context, query string, offset, limit int32) ([]notes.SearchResult, error) {
+	query = strings.ReplaceAll(query, "%", "*")
+	query = strings.ReplaceAll(query, "_", "?")
+	rows, err := r.q.SearchNotes(ctx, gen.SearchNotesParams{
+		Content: query,
+		Limit:   int64(limit),
+		Offset:  int64(offset),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]notes.SearchResult, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, notes.SearchResult{
+			ID:        row.ID,
+			Path:      row.Path,
+			UpdatedAt: row.UpdatedAt,
+		})
+	}
+	return out, nil
 }
 
 func (r *SqliteNotesRepository) ListNotes(ctx context.Context) ([]notes.Note, error) {

--- a/markupp/internal/storage/notes_integration_test.go
+++ b/markupp/internal/storage/notes_integration_test.go
@@ -119,7 +119,7 @@ func TestSearchNotes_NaoEncontra_RetornaVazio(t *testing.T) {
 	assert.Empty(t, results)
 }
 
-func TestSearchNotes_LikeEhCaseSensitive(t *testing.T) {
+func TestSearchNotes_LikeEhCaseInsensitive(t *testing.T) {
 	db := setupIntegrationTestDB(t)
 	defer db.Close()
 	repo := storage.NewSqliteNotesRepository(db)
@@ -135,12 +135,11 @@ func TestSearchNotes_LikeEhCaseSensitive(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Buscar por "golang" (minúscula)
+	// Buscar por "golang" (minúscula) - LIKE é case-insensitive
 	results, err := repo.SearchNotes(ctx, "%golang%", 0, 10)
 
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "2", results[0].ID)
+	require.Len(t, results, 2)
 }
 
 func setupIntegrationTestDB(t *testing.T) *sql.DB {

--- a/markupp/internal/storage/notes_integration_test.go
+++ b/markupp/internal/storage/notes_integration_test.go
@@ -1,0 +1,163 @@
+package storage_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ifsc-ES2/projeto-markupp/markupp/internal/notes"
+	"github.com/ifsc-ES2/projeto-markupp/markupp/internal/storage"
+	_ "modernc.org/sqlite"
+)
+
+func TestSearchNotes_ComResultados_RetornaPaginado(t *testing.T) {
+	db := setupIntegrationTestDB(t)
+	defer db.Close()
+	repo := storage.NewSqliteNotesRepository(db)
+	ctx := context.Background()
+
+	// Inserir dados de teste
+	now := time.Now()
+	notesData := []notes.Note{
+		{ID: "1", Path: "golang1.md", Content: "golang tutorial", CreatedAt: now, UpdatedAt: now},
+		{ID: "2", Path: "golang2.md", Content: "golang tips", CreatedAt: now, UpdatedAt: now},
+		{ID: "3", Path: "python.md", Content: "python guide", CreatedAt: now, UpdatedAt: now},
+		{ID: "4", Path: "golang3.md", Content: "golang advanced", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, note := range notesData {
+		err := repo.Save(ctx, note)
+		require.NoError(t, err)
+	}
+
+	// Buscar por "golang"
+	results, err := repo.SearchNotes(ctx, "%golang%", 0, 10)
+
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	// Verificar que retorna apenas id, path e updatedAt
+	assert.Equal(t, "1", results[0].ID)
+	assert.Equal(t, "golang1.md", results[0].Path)
+	assert.Equal(t, now.Unix(), results[0].UpdatedAt.Unix())
+}
+
+func TestSearchNotes_ComPaginacao_RetornaApenasLimitAndOffset(t *testing.T) {
+	db := setupIntegrationTestDB(t)
+	defer db.Close()
+	repo := storage.NewSqliteNotesRepository(db)
+	ctx := context.Background()
+
+	// Inserir 5 notas com "golang"
+	now := time.Now()
+	for i := 1; i <= 5; i++ {
+		note := notes.Note{
+			ID:        string(rune('0' + i)),
+			Path:      "golang" + string(rune('0'+i)) + ".md",
+			Content:   "golang content " + string(rune('0'+i)),
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		err := repo.Save(ctx, note)
+		require.NoError(t, err)
+	}
+
+	// Buscar com offset=1 e limit=2
+	results, err := repo.SearchNotes(ctx, "%golang%", 1, 2)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+}
+
+func TestSearchNotes_OffsetMaiorQueTotal_RetornaVazio(t *testing.T) {
+	db := setupIntegrationTestDB(t)
+	defer db.Close()
+	repo := storage.NewSqliteNotesRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	note := notes.Note{
+		ID:        "1",
+		Path:      "golang.md",
+		Content:   "golang tutorial",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	err := repo.Save(ctx, note)
+	require.NoError(t, err)
+
+	// Offset > total de resultados
+	results, err := repo.SearchNotes(ctx, "%golang%", 100, 10)
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestSearchNotes_NaoEncontra_RetornaVazio(t *testing.T) {
+	db := setupIntegrationTestDB(t)
+	defer db.Close()
+	repo := storage.NewSqliteNotesRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	note := notes.Note{
+		ID:        "1",
+		Path:      "python.md",
+		Content:   "python tutorial",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	err := repo.Save(ctx, note)
+	require.NoError(t, err)
+
+	// Buscar por algo que não existe
+	results, err := repo.SearchNotes(ctx, "%golang%", 0, 10)
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestSearchNotes_LikeEhCaseSensitive(t *testing.T) {
+	db := setupIntegrationTestDB(t)
+	defer db.Close()
+	repo := storage.NewSqliteNotesRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	notesData := []notes.Note{
+		{ID: "1", Path: "a.md", Content: "Golang Tutorial", CreatedAt: now, UpdatedAt: now},
+		{ID: "2", Path: "b.md", Content: "golang tips", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, note := range notesData {
+		err := repo.Save(ctx, note)
+		require.NoError(t, err)
+	}
+
+	// Buscar por "golang" (minúscula)
+	results, err := repo.SearchNotes(ctx, "%golang%", 0, 10)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "2", results[0].ID)
+}
+
+func setupIntegrationTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	// Criar tabela de testes
+	_, err = db.Exec(`
+		CREATE TABLE notes (
+			id TEXT PRIMARY KEY,
+			path TEXT UNIQUE NOT NULL,
+			content TEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)
+	`)
+	require.NoError(t, err)
+
+	return db
+}

--- a/markupp/internal/storage/queries/notes.sql
+++ b/markupp/internal/storage/queries/notes.sql
@@ -17,3 +17,9 @@ RETURNING id, path, content, created_at, updated_at;
 
 -- name: DeleteNote :execrows
 DELETE FROM notes WHERE id = ?;
+
+-- name: SearchNotes :many
+SELECT id, path, updated_at FROM notes
+WHERE content GLOB ?
+ORDER BY updated_at DESC
+LIMIT ? OFFSET ?;

--- a/markupp/internal/storage/queries/notes.sql
+++ b/markupp/internal/storage/queries/notes.sql
@@ -20,6 +20,6 @@ DELETE FROM notes WHERE id = ?;
 
 -- name: SearchNotes :many
 SELECT id, path, updated_at FROM notes
-WHERE content GLOB ?
+WHERE content LIKE ?
 ORDER BY updated_at DESC
 LIMIT ? OFFSET ?;


### PR DESCRIPTION
## O que mudou
- Criada a rota de busca para `GET /notes/search` usando query string.
- `notesHandler.search` agora lê `query`, `offset` e `limit`, validando os valores e aplicando defaults.
- `notes.Service.Search` passou a aceitar `offset` e `limit`, com normalização de valores negativos e default de `limit = 10`.
- Repositório SQLite `SearchNotes` criado.
- Atualizados testes de API e de storage para cobrir a nova rota de busca e paginação.
- Corrigido `Makefile` para que `make test` execute corretamente.

## Por quê
- Para suportar paginação real na busca de notas.
- Para tornar a API mais consistente e alinhada com padrões de query string.
- Para corrigir problemas de compilação e garantir que os testes automatizados executem.

## Como testar
- Executar `make test`
- Verificar que todos os pacotes passam: `internal/api`, `internal/notes` e `internal/storage`
- Opcional: fazer um request manual em `GET /notes/search?query=golang&offset=0&limit=10`

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
