### PR TITLE
refact: isola detalhes de persistencia na camada de storage

### DIFF
--- a/docs/adrs/ADR-0009-isolamento-persistencia.md
+++ b/docs/adrs/ADR-0009-isolamento-persistencia.md
@@ -1,0 +1,25 @@
+# ADR-0009: Detalhes de persistência isolados na camada de storage
+
+## Contexto
+
+As camadas api -> notes -> storage existem, mas detalhes de persistência vazam para
+cima: api e notes importam database/sql e tratam sql.ErrNoRows, e o domínio monta a
+sintaxe de LIKE do SQL
+
+## Decisão
+
+A camada de storage é a única que conhece database/sql e SQL. Ela traduz erros de
+persistência para erros de domínio (sql.ErrNoRows vira notes.ErrNotFound) e monta as
+queries. As camadas acima falam apenas erros de domínio
+
+## Alternativas consideradas
+
+- Manter o tratamento de sql.ErrNoRows na API (status quo): acopla a API ao driver,
+  trocar o storage exigiria mexer na API
+
+## Consequências
+
+- API e domínio independentes do driver de persistência
+- Trocar o storage não afeta as camadas superiores
+- Erros de domínio são o contrato único entre camadas
+- O storage precisa traduzir os erros de persistência explicitamente

--- a/markupp/internal/api/notes_handler.go
+++ b/markupp/internal/api/notes_handler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -182,8 +181,6 @@ func writeError(w http.ResponseWriter, code, message string, status int) {
 
 func writeDomainError(w http.ResponseWriter, err error) {
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
-		writeError(w, "not_found", "nota não encontrada", http.StatusNotFound)
 	case errors.Is(err, notes.ErrInvalidPath):
 		writeError(w, "invalid_path", notes.ErrInvalidPath.Error(), http.StatusBadRequest)
 	case errors.Is(err, notes.ErrInvalidContent):
@@ -194,8 +191,6 @@ func writeDomainError(w http.ResponseWriter, err error) {
 		writeError(w, "not_found", notes.ErrNotFound.Error(), http.StatusNotFound)
 	case errors.Is(err, notes.ErrInvalidId):
 		writeError(w, "invalid_id", notes.ErrInvalidId.Error(), http.StatusBadRequest)
-	case errors.Is(err, notes.ErrNotFoundId):
-		writeError(w, "not_found", "nota não encontrada", http.StatusNotFound)
 	default:
 		writeError(w, "internal", "erro interno", http.StatusInternalServerError)
 	}

--- a/markupp/internal/api/notes_handler_test.go
+++ b/markupp/internal/api/notes_handler_test.go
@@ -289,7 +289,7 @@ func TestGetNotes_IDValido_Retorna200(t *testing.T) {
 	assert.Equal(t, "y", resp["content"])
 }
 
-func TestGetNotes_IDVazio_Retorna404(t *testing.T) {
+func TestGetNotes_RotaSemId_Retorna404(t *testing.T) {
 	svc := &fakeService{}
 	rec := doGet(t, svc, "")
 
@@ -355,16 +355,20 @@ func TestGetNotes_IDNaoEncontrado_ComServiceReal_Retorna404(t *testing.T) {
 	assert.Equal(t, "not_found", resp["error"])
 }
 
-func TestGetNotes_IDVazio_ComServiceReal_Retorna400(t *testing.T) {
+func TestGetNotes_IdEmBranco_ComServiceReal_Retorna400(t *testing.T) {
 	repo := &stubRepository{}
 	svc := notes.NewService(repo, 1000)
 
 	router := api.NewRouter(svc)
-	req := httptest.NewRequest(http.MethodGet, "/notes/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/notes/%20", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "invalid_id", resp["error"])
 }
 
 func TestGetNotes_IDValido_ComServiceReal_Retorna200(t *testing.T) {

--- a/markupp/internal/api/notes_handler_test.go
+++ b/markupp/internal/api/notes_handler_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -298,7 +297,7 @@ func TestGetNotes_IDVazio_Retorna404(t *testing.T) {
 }
 
 func TestGetNotes_IDNaoEncontrado_Retorna404(t *testing.T) {
-	svc := &fakeService{err: sql.ErrNoRows}
+	svc := &fakeService{err: notes.ErrNotFound}
 	rec := doGet(t, svc, "id-inexistente")
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
@@ -341,7 +340,7 @@ func (s *stubRepository) SearchNotes(ctx context.Context, query string, offset, 
 }
 
 func TestGetNotes_IDNaoEncontrado_ComServiceReal_Retorna404(t *testing.T) {
-	repo := &stubRepository{getError: sql.ErrNoRows}
+	repo := &stubRepository{getError: notes.ErrNotFound}
 	svc := notes.NewService(repo, 1000)
 
 	router := api.NewRouter(svc)

--- a/markupp/internal/notes/notes.go
+++ b/markupp/internal/notes/notes.go
@@ -158,8 +158,7 @@ func (s *Service) SearchNotes(ctx context.Context, query string, offset, limit i
 		limit = 10
 	}
 
-	searchQuery := "%" + query + "%"
-	results, err := s.repo.SearchNotes(ctx, searchQuery, int32(offset), int32(limit))
+	results, err := s.repo.SearchNotes(ctx, query, int32(offset), int32(limit))
 	if err != nil {
 		return nil, fmt.Errorf("buscar notas: %w", err)
 	}

--- a/markupp/internal/notes/notes.go
+++ b/markupp/internal/notes/notes.go
@@ -58,7 +58,7 @@ func NewService(repo Repository, maxContentSize int64) *Service {
 }
 
 func (s *Service) GetNoteById(ctx context.Context, id string) (Note, error) {
-	if err := s.validateId(ctx, id); err != nil {
+	if err := validateId(id); err != nil {
 		return Note{}, err
 	}
 	return s.repo.GetNoteByID(ctx, id)
@@ -90,8 +90,8 @@ func (s *Service) Create(ctx context.Context, path, content string) (Note, error
 }
 
 func (s *Service) Update(ctx context.Context, id, path, content string) (Note, error) {
-	if strings.TrimSpace(id) == "" {
-		return Note{}, ErrNotFound
+	if err := validateId(id); err != nil {
+		return Note{}, err
 	}
 	if err := validatePath(path); err != nil {
 		return Note{}, err
@@ -110,7 +110,7 @@ func (s *Service) Update(ctx context.Context, id, path, content string) (Note, e
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {
-	if err := s.validateId(ctx, id); err != nil {
+	if err := validateId(id); err != nil {
 		return err
 	}
 	if err := s.repo.Delete(ctx, id); err != nil {
@@ -122,7 +122,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Service) validateId(ctx context.Context, id string) error {
+func validateId(id string) error {
 	if strings.TrimSpace(id) == "" {
 		return ErrInvalidId
 	}

--- a/markupp/internal/notes/notes.go
+++ b/markupp/internal/notes/notes.go
@@ -2,7 +2,6 @@ package notes
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -40,7 +39,6 @@ var (
 	ErrDuplicatePath  = errors.New("path já existe")
 	ErrNotFound       = errors.New("nota não encontrada")
 	ErrInvalidId      = errors.New("ID inválido")
-	ErrNotFoundId     = errors.New("ID não encontrado")
 )
 
 type Service struct {
@@ -63,12 +61,7 @@ func (s *Service) GetNoteById(ctx context.Context, id string) (Note, error) {
 	if err := s.validateId(ctx, id); err != nil {
 		return Note{}, err
 	}
-
-	note, err := s.repo.GetNoteByID(ctx, id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return Note{}, ErrNotFoundId
-	}
-	return note, err
+	return s.repo.GetNoteByID(ctx, id)
 }
 
 func (s *Service) ListNotes(ctx context.Context) ([]Note, error) {

--- a/markupp/internal/notes/service_test.go
+++ b/markupp/internal/notes/service_test.go
@@ -2,7 +2,6 @@ package notes_test
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -296,14 +295,14 @@ func TestGetNoteById_IDVazio_RetornaErrInvalidId(t *testing.T) {
 	assert.True(t, errors.Is(err, notes.ErrInvalidId))
 }
 
-func TestGetNoteById_IDNaoEncontrado_RetornaErrNotFoundId(t *testing.T) {
-	repo := &fakeRepo{getErr: sql.ErrNoRows}
+func TestGetNoteById_IDNaoEncontrado_RetornaErrNotFound(t *testing.T) {
+	repo := &fakeRepo{getErr: notes.ErrNotFound}
 	svc := newServiceForTest(repo)
 
 	_, err := svc.GetNoteById(context.Background(), "id-inexistente")
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, notes.ErrNotFoundId))
+	assert.True(t, errors.Is(err, notes.ErrNotFound))
 }
 
 func TestGetNoteById_CaminhoFeliz_RetornaNotaCorreta(t *testing.T) {

--- a/markupp/internal/notes/service_test.go
+++ b/markupp/internal/notes/service_test.go
@@ -177,14 +177,14 @@ func TestCreate_RepoRetornaErrDuplicatePath_PropagadoAoCaller(t *testing.T) {
 	assert.True(t, errors.Is(err, notes.ErrDuplicatePath))
 }
 
-func TestUpdate_IDVazio_RetornaErrNotFound(t *testing.T) {
+func TestUpdate_IDVazio_RetornaErrInvalidId(t *testing.T) {
 	repo := &fakeRepo{}
 	svc := newServiceForTest(repo)
 
 	_, err := svc.Update(context.Background(), "", "ok.md", "x")
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, notes.ErrNotFound))
+	assert.True(t, errors.Is(err, notes.ErrInvalidId))
 	assert.False(t, repo.updateArgs.called)
 }
 

--- a/markupp/internal/notes/service_test.go
+++ b/markupp/internal/notes/service_test.go
@@ -410,9 +410,8 @@ func TestSearch_PaginacaoComOffset_PassaParametrosCorretosAoRepo(t *testing.T) {
 	require.Len(t, results, 2)
 	assert.Equal(t, "id-2", results[0].ID)
 	assert.Equal(t, "id-3", results[1].ID)
-	// Valida que os parâmetros foram passados corretamente (com wildcards)
 	assert.True(t, repo.searchArgs.called)
-	assert.Equal(t, "%golang%", repo.searchArgs.query)
+	assert.Equal(t, "golang", repo.searchArgs.query)
 	assert.Equal(t, int32(1), repo.searchArgs.offset)
 	assert.Equal(t, int32(2), repo.searchArgs.limit)
 }
@@ -447,22 +446,22 @@ func TestSearch_OffsetNegativo_UsaZero(t *testing.T) {
 	assert.Equal(t, int32(0), repo.searchArgs.offset)
 }
 
-func TestSearch_AdicionaWildcardsNaQuery(t *testing.T) {
+func TestSearch_PassaQueryCruaAoRepo(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
 	_, err := svc.SearchNotes(context.Background(), "test", 0, 10)
 	require.NoError(t, err)
 
-	assert.Equal(t, "%test%", repo.searchArgs.query)
+	assert.Equal(t, "test", repo.searchArgs.query)
 }
 
-func TestSearch_QueryVazioComWildcards(t *testing.T) {
+func TestSearch_QueryVazia_PassaVaziaAoRepo(t *testing.T) {
 	repo := &fakeRepo{searchResult: []notes.SearchResult{}}
 	svc := newServiceForTest(repo)
 
 	_, err := svc.SearchNotes(context.Background(), "", 0, 10)
 	require.NoError(t, err)
 
-	assert.Equal(t, "%%", repo.searchArgs.query)
+	assert.Equal(t, "", repo.searchArgs.query)
 }

--- a/markupp/internal/storage/notes.go
+++ b/markupp/internal/storage/notes.go
@@ -78,6 +78,9 @@ func (r *SqliteNotesRepository) Delete(ctx context.Context, id string) error {
 func (r *SqliteNotesRepository) GetNoteByID(ctx context.Context, id string) (notes.Note, error) {
 	row, err := r.q.GetNoteByID(ctx, id)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return notes.Note{}, notes.ErrNotFound
+		}
 		return notes.Note{}, err
 	}
 	return notes.Note{

--- a/markupp/internal/storage/notes.go
+++ b/markupp/internal/storage/notes.go
@@ -94,7 +94,7 @@ func (r *SqliteNotesRepository) GetNoteByID(ctx context.Context, id string) (not
 
 func (r *SqliteNotesRepository) SearchNotes(ctx context.Context, query string, offset, limit int32) ([]notes.SearchResult, error) {
 	rows, err := r.q.SearchNotes(ctx, gen.SearchNotesParams{
-		Content: query,
+		Content: "%" + query + "%",
 		Limit:   int64(limit),
 		Offset:  int64(offset),
 	})

--- a/markupp/internal/storage/notes_integration_test.go
+++ b/markupp/internal/storage/notes_integration_test.go
@@ -33,8 +33,7 @@ func TestSearchNotes_ComResultados_RetornaPaginado(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Buscar por "golang"
-	results, err := repo.SearchNotes(ctx, "%golang%", 0, 10)
+	results, err := repo.SearchNotes(ctx, "golang", 0, 10)
 
 	require.NoError(t, err)
 	require.Len(t, results, 3)
@@ -64,8 +63,7 @@ func TestSearchNotes_ComPaginacao_RetornaApenasLimitAndOffset(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Buscar com offset=1 e limit=2
-	results, err := repo.SearchNotes(ctx, "%golang%", 1, 2)
+	results, err := repo.SearchNotes(ctx, "golang", 1, 2)
 
 	require.NoError(t, err)
 	require.Len(t, results, 2)
@@ -88,8 +86,7 @@ func TestSearchNotes_OffsetMaiorQueTotal_RetornaVazio(t *testing.T) {
 	err := repo.Save(ctx, note)
 	require.NoError(t, err)
 
-	// Offset > total de resultados
-	results, err := repo.SearchNotes(ctx, "%golang%", 100, 10)
+	results, err := repo.SearchNotes(ctx, "golang", 100, 10)
 
 	require.NoError(t, err)
 	assert.Empty(t, results)
@@ -112,8 +109,7 @@ func TestSearchNotes_NaoEncontra_RetornaVazio(t *testing.T) {
 	err := repo.Save(ctx, note)
 	require.NoError(t, err)
 
-	// Buscar por algo que não existe
-	results, err := repo.SearchNotes(ctx, "%golang%", 0, 10)
+	results, err := repo.SearchNotes(ctx, "golang", 0, 10)
 
 	require.NoError(t, err)
 	assert.Empty(t, results)
@@ -135,11 +131,28 @@ func TestSearchNotes_LikeEhCaseInsensitive(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Buscar por "golang" (minúscula) - LIKE é case-insensitive
-	results, err := repo.SearchNotes(ctx, "%golang%", 0, 10)
+	results, err := repo.SearchNotes(ctx, "golang", 0, 10)
 
 	require.NoError(t, err)
 	require.Len(t, results, 2)
+}
+
+func TestSearchNotes_QueryParcial_CasaSubstring(t *testing.T) {
+	db := setupIntegrationTestDB(t)
+	defer db.Close()
+	repo := storage.NewSqliteNotesRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	require.NoError(t, repo.Save(ctx, notes.Note{
+		ID: "1", Path: "g.md", Content: "golang tutorial", CreatedAt: now, UpdatedAt: now,
+	}))
+
+	results, err := repo.SearchNotes(ctx, "olang", 0, 10)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "1", results[0].ID)
 }
 
 func setupIntegrationTestDB(t *testing.T) *sql.DB {

--- a/markupp/internal/storage/notes_integration_test.go
+++ b/markupp/internal/storage/notes_integration_test.go
@@ -20,7 +20,6 @@ func TestSearchNotes_ComResultados_RetornaPaginado(t *testing.T) {
 	repo := storage.NewSqliteNotesRepository(db)
 	ctx := context.Background()
 
-	// Inserir dados de teste
 	now := time.Now()
 	notesData := []notes.Note{
 		{ID: "1", Path: "golang1.md", Content: "golang tutorial", CreatedAt: now, UpdatedAt: now},
@@ -37,7 +36,6 @@ func TestSearchNotes_ComResultados_RetornaPaginado(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, results, 3)
-	// Verificar que retorna apenas id, path e updatedAt
 	assert.Equal(t, "1", results[0].ID)
 	assert.Equal(t, "golang1.md", results[0].Path)
 	assert.Equal(t, now.Unix(), results[0].UpdatedAt.Unix())
@@ -49,7 +47,6 @@ func TestSearchNotes_ComPaginacao_RetornaApenasLimitAndOffset(t *testing.T) {
 	repo := storage.NewSqliteNotesRepository(db)
 	ctx := context.Background()
 
-	// Inserir 5 notas com "golang"
 	now := time.Now()
 	for i := 1; i <= 5; i++ {
 		note := notes.Note{
@@ -159,7 +156,6 @@ func setupIntegrationTestDB(t *testing.T) *sql.DB {
 	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 
-	// Criar tabela de testes
 	_, err = db.Exec(`
 		CREATE TABLE notes (
 			id TEXT PRIMARY KEY,

--- a/markupp/internal/storage/notes_test.go
+++ b/markupp/internal/storage/notes_test.go
@@ -181,3 +181,13 @@ func TestSqliteRepo_ListNotes_RetornaTodasNotasOrdenadasPorPath(t *testing.T) {
 	assert.Equal(t, "c.md", got[2].Path)
 	assert.Equal(t, "aaa", got[0].Content)
 }
+
+func TestSqliteRepo_GetNoteByID_IDInexistente_RetornaErrNotFound(t *testing.T) {
+	db := setupTestDB(t)
+	repo := storage.NewSqliteNotesRepository(db)
+
+	_, err := repo.GetNoteByID(context.Background(), "nao-existe")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, notes.ErrNotFound))
+}


### PR DESCRIPTION
## O que mudou
- a camada storage virou a unica que conhece database/sql e SQL
- storage traduz sql.ErrNoRows para o erro de dominio notes.ErrNotFound
- api e notes nao importam mais database/sql
- removido o erro redundante ErrNotFoundId
- a montagem do LIKE saiu do dominio para o storage
- a validacao de id foi unificada em Get, Update e Delete (id em branco retorna invalid_id)
- adicionado o ADR-0009 sobre a fronteira de persistencia

## Por que
- detalhes de persistencia vazavam para cima e acoplavam api e dominio ao driver
- agora trocar o storage nao afeta api nem dominio
- **metrica antes/depois, houve melhoria:**
  - violacoes de fronteira: 3 para 0
  - complexidade ciclomatica: writeDomainError 8 para 6, GetNoteById 3 para 2

## Como testar
- cd markupp e rodar go test ./... -race -count=1
- gofmt -l . , go vet ./... e golangci-lint run limpos
- complexidade ciclomatica: cd markupp e rodar go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -top 20 internal cmd

## Auto-review (checklist)
- [x] Descricao clara (o que/por que/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidencia de teste (manual ou automatizado)