### PR TITLE
docs: deploy requierement

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -60,8 +60,6 @@ curl -s -X DELETE http://localhost:8080/notes/$ID -w '%{http_code}\n'
 
 Esperado: `POST` retorna JSON com `id` UUID, `GET` traz a nota, `DELETE` responde `204`. Rotas completas em `markupp/openapi.yaml`.
 
-Validação pelo plugin: abra uma nota no Obsidian e execute o comando **"Subir nota ativa"**.
-
 ## Build a partir do código fonte
 
 Útil pra contribuir ou reproduzir a imagem localmente.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,85 @@
+# Deploy
+
+O Markupp tem dois artefatos: o **servidor** em Go e o **plugin Obsidian**. O servidor expõe a API REST e o plugin é o cliente que envia notas.
+
+## Pré-requisitos
+
+- Docker 24+ para rodar o servidor.
+- Obsidian 1.5+ para o plugin.
+- (Opcional, só pra buildar do código) Go 1.26 e Node 20+.
+
+## Subir o servidor
+
+Com Docker instalado:
+
+```sh
+docker run -d --name markupp -p 8080:8080 -v markupp_data:/data riedelgab/ifsces2:latest
+```
+
+- Servidor disponível em `http://localhost:8080`.
+- Banco SQLite persistido no volume `markupp_data`.
+- Para parar e remover: `docker stop markupp && docker rm markupp`.
+
+### Configuração (opcional)
+
+Os defaults atendem a maioria dos casos. Para mudar porta ou tamanho máximo de nota, monte um `config.json` no container:
+
+```sh
+docker run -d --name markupp \
+  -p 9090:9090 \
+  -v markupp_data:/data \
+  -v "$(pwd)/config.json:/data/config.json" \
+  riedelgab/ifsces2:latest
+```
+
+| Chave | Default | O que é |
+| --- | --- | --- |
+| `port` | `8080` | Porta HTTP |
+| `db_path` | `./markupp.db` | Arquivo SQLite |
+| `max_note_size` | `52428800` | Tamanho máximo de uma nota (bytes) |
+
+## Instalar o plugin no Obsidian
+
+1. Baixe `main.js`, `manifest.json` e `styles.css` da [release mais recente](https://github.com/IFSC-ES2/projeto-markupp/releases).
+2. Copie os três arquivos para `<seu-vault>/.obsidian/plugins/obsidian-markupp-plugin/`.
+3. Em **Settings → Community Plugins**, habilite "Markupp Plugin".
+4. Em **Settings → Markupp Plugin**, configure a URL do servidor (default `http://localhost:8080`).
+
+## Validar
+
+Smoke test pela API (sem precisar do Obsidian):
+
+```sh
+ID=$(curl -s -X POST http://localhost:8080/notes \
+  -H 'Content-Type: application/json' \
+  -d '{"path":"validacao.md","content":"oi"}' \
+  | grep -o '"id":"[^"]*"' | cut -d'"' -f4)
+curl -s http://localhost:8080/notes/$ID
+curl -s -X DELETE http://localhost:8080/notes/$ID -w '%{http_code}\n'
+```
+
+Esperado: `POST` retorna JSON com `id` UUID, `GET` traz a nota, `DELETE` responde `204`. Rotas completas em `markupp/openapi.yaml`.
+
+Validação pelo plugin: abra uma nota no Obsidian e execute o comando **"Subir nota ativa"**.
+
+## Build a partir do código fonte
+
+Útil pra contribuir ou reproduzir a imagem localmente.
+
+```sh
+# servidor
+cd markupp
+go build -o markupp ./cmd/markupp
+./markupp
+
+# plugin
+cd obsidian-plugin
+npm ci
+npm run build
+```
+
+A imagem Docker é gerada por `markupp/Dockerfile` (multi-stage, alpine, ~20MB). O workflow `.github/workflows/release.yml` publica `riedelgab/ifsces2` em cada tag `v*`.
+
+## Aviso
+
+O servidor não tem autenticação ([ADR-0005](adrs/ADR-0005-seguranca-fora-do-mvp.md)). **Não exponha fora de `localhost`** — qualquer um com acesso à porta consegue ler, criar e apagar notas.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -60,6 +60,8 @@ curl -s -X DELETE http://localhost:8080/notes/$ID -w '%{http_code}\n'
 
 Esperado: `POST` retorna JSON com `id` UUID, `GET` traz a nota, `DELETE` responde `204`. Rotas completas em `markupp/openapi.yaml`.
 
+Para validar pelo plugin: abra a Source Control View (ícone na barra lateral ou o comando "Abrir source control"), edite/crie uma nota no vault e rode Push (ou Sync). A nota deve aparecer no servidor (confirme com o GET /notes).
+
 ## Build a partir do código fonte
 
 Útil pra contribuir ou reproduzir a imagem localmente.


### PR DESCRIPTION
## O que mudou
  - Adiciona `docs/DEPLOY.md` documentando build, execução, instalação do plugin no Obsidian, validação por smoke test da API e limitações conhecidas do MVP.

  ## Por quê
  - Item 3 da Entrega 8 (Sprint 4) exige um `DEPLOY.md` em `docs/` cobrindo pré-requisitos, variáveis de ambiente, comandos de build/execução, processo de deploy, validação e reprodução local. Sem ele a entrega fica incompleta.

  ## Como testar
  - Abrir `docs/DEPLOY.md` e seguir os comandos:
    - `make run` deve subir o servidor em `http://localhost:8080`.
    - O smoke test com `curl` (POST → GET → DELETE em `/notes`) deve retornar 201, 200 e 204 respectivamente.
    - `cd obsidian-plugin && npm ci && npm run build` gera `main.js`.

  ## Auto-review (checklist)
  - [x] Descrição clara (o que/por quê/como testar)
  - [x] PR pequeno e focado
  - [x] Casos limite considerados (ex.: vazio, 0, erro)
  - [x] Evidência de teste (manual ou automatizado)