### PR TITLE
feat: CD do plugin, ADR-0011 e contribuições da Sprint 4 (Entrega 8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release plugin
+
+# Ao publicar uma release (ex.: v0.4.0), builda o plugin e anexa o artefato
+# instalável à própria release. É o passo de CD do lado do plugin: o usuário
+# baixa o zip da release e instala no Obsidian sem precisar buildar.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  plugin-artifact:
+    name: Build e anexa o plugin na release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: obsidian-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: obsidian-plugin/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Empacota o artefato do plugin
+        run: |
+          cd build
+          zip "../markupp-plugin-${{ github.event.release.tag_name }}.zip" \
+            main.js manifest.json styles.css
+
+      - name: Anexa os arquivos na release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "markupp-plugin-${{ github.event.release.tag_name }}.zip" \
+            build/main.js build/manifest.json build/styles.css \
+            --clobber

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Excesso de informação descentralizada e dados desestruturados sem métodos de 
 - Expor uma API REST que permita integração com clientes
 - Processar documentos automaticamente para busca semântica
 
+## Instalação do plugin (Obsidian)
+1. Baixe o artefato da release `v0.4.0`: `markupp-plugin-v0.4.0.zip` (ou os arquivos `main.js`, `manifest.json` e `styles.css` anexados à release).
+2. Crie a pasta `<seu-vault>/.obsidian/plugins/obsidian-markupp-plugin/` e coloque os três arquivos nela (extraia o zip aqui).
+3. No Obsidian: **Configurações → Plugins da comunidade**, ative o **Markupp**.
+4. Nas opções do plugin, ajuste o **`serverUrl`** (padrão `http://localhost:8080`) para o endereço do servidor Markupp.
+5. Use o ícone na barra lateral ou os comandos **Fetch / Pull / Push / Sync** para sincronizar suas notas.
+
+> Para subir o servidor e validar o ambiente, veja [docs/DEPLOY.md](docs/DEPLOY.md).
+
 ## Governança
 **Q: Quem pode abrir PR?**
 > `A: Todos.`
@@ -57,3 +66,4 @@ O fluxo de trabalho do projeto está documentado em [fluxo de trabalho](docs/flu
 - [ADRs](docs/adrs/)
 - [Métricas](docs/metricas.md)
 - [Contribuições da Sprint 3](docs/contribuicoes-sprint3.md)
+- [Contribuições da Sprint 4](docs/contribuicoes-sprint4.md)

--- a/docs/adrs/ADR-0011-source-control-view.md
+++ b/docs/adrs/ADR-0011-source-control-view.md
@@ -1,0 +1,54 @@
+# ADR-0011: Source Control View no plugin, no lugar dos comandos avulsos
+
+## Contexto
+
+A primeira versão da sincronização do plugin era um conjunto de comandos avulsos em
+`src/commands/` (`sync`, `sync-all`, `upload`, `import`, `download`). Cada comando
+reimplementava partes do mesmo fluxo (buscar remoto -> diferenciar -> aplicar ->
+persistir meta), o que gerava duplicação, dificultava enxergar o estado de sincronização
+e não dava ao usuário uma visão do que iria subir/descer antes de agir.
+
+## Decisão
+
+Consolidar a lógica numa camada de orquestração (`src/core/operations.ts`) sobre um motor
+de status (`src/core/status.ts`), e expor isso por uma **Source Control View** estilo git
+(`src/ui/sourceControl/view.ts`), com as operações `fetch`, `pull`, `push` e `sync`. O par
+de persistência de meta (`setNoteMeta` + `syncRemoteSnapshot`), antes repetido em cada
+`apply*`, foi extraído para o helper único `recordSynced`. `forcePush`/`forcePull` deixam de
+reimplementar create/update/delete e passam a reaproveitar os mesmos `apply*` com um
+parâmetro `force`.
+
+## Alternativas consideradas
+
+- Manter os comandos avulsos (status quo): cada comando duplica o fluxo e não há uma visão
+  única de status; evoluir a sincronização exige mexer em vários arquivos paralelos.
+- Só extrair helpers, sem a view: reduz duplicação mas não resolve a falta de visibilidade
+  do estado para o usuário.
+
+## Consequências
+
+- Uma única camada (`core/`) concentra a lógica de sincronização, consumida pela view e
+  pelos comandos finos do `main.ts`.
+- O usuário passa a ver o diff (novo/modificado/deletado/conflito) antes de aplicar.
+- Push/pull ficaram resilientes a falha parcial e a conflito 409 (optimistic locking):
+  o `saveData` num `finally` e o conflito contado como `skipped` em vez de abortar o lote.
+- Menos duplicação, porém a camada `core/` concentra responsabilidade e precisa de bons testes
+  (cobertos em `operations.test.ts` e `status.test.ts`).
+
+## Métrica antes/depois (reengenharia — Entrega 8)
+
+Medido entre o ponto de partida da branch (`76f3145`) e o estado final do PR #79 (`0299ec3`).
+
+| Métrica | Antes | Depois |
+|---|---|---|
+| Módulos de comando com lógica de sync duplicada (`src/commands/*.ts`) | 5 arquivos (413 LOC) | 0 (removidos) |
+| Camada que concentra a sincronização | dispersa nos 5 comandos | `core/operations.ts` (384) + `core/status.ts` (108) |
+| Repetição do par persistir-meta (`setNoteMeta`+`syncRemoteSnapshot`) inline | 5 pontos | 1 helper `recordSynced` (4 chamadas) |
+| Reimplementação de create/update/delete em `forcePush` | sim | reaproveita `apply*` com parâmetro `force` |
+| Visão de status para o usuário antes de aplicar | nenhuma | Source Control View (diff novo/modificado/deletado/conflito) |
+
+**Análise:** não é uma redução bruta de linhas — é reorganização para coesão e remoção de
+duplicação. A lógica de sincronização, antes espalhada e repetida em 5 comandos, passou a ter
+uma fonte única (`core/`), o ponto de persistência de meta deixou de ser copiado em cada
+caminho (5 -> 1), e `forcePush` parou de duplicar o CRUD. O ganho é de manutenibilidade e de
+visibilidade do estado, não de tamanho do código.

--- a/docs/contribuicoes-sprint4.md
+++ b/docs/contribuicoes-sprint4.md
@@ -4,7 +4,8 @@ Janela: marco da Sprint 3 (29/05) ao marco da Sprint 4 (08/06). Cada membro conf
 
 ## Gabriela Riedel
 
-- a confirmar pela própria
+- Adição do arquivo DEPLOY.md
+- Adição do Dockerfile para publicação no Dockerhub + uso na CI
 
 ## Luís Renato Freitas de Almeida
 

--- a/docs/contribuicoes-sprint4.md
+++ b/docs/contribuicoes-sprint4.md
@@ -27,5 +27,7 @@ Janela: marco da Sprint 3 (29/05) ao marco da Sprint 4 (08/06). Cada membro conf
 
 ## Nicolas Pitz
 
-- a confirmar pelo próprio
+- Adicionada feature de sincronização do servidor, com flags e uma nova rota.
+- Atualiza Testes para incluir nova rota e services.
+- Atualiza baseline registrando os novos avanços do projeto.
 - Métricas da Sprint 4 nas fichas de `docs/metricas/`.

--- a/docs/contribuicoes-sprint4.md
+++ b/docs/contribuicoes-sprint4.md
@@ -1,0 +1,30 @@
+# Contribuições individuais, Sprint 4
+
+Janela: marco da Sprint 3 (29/05) ao marco da Sprint 4 (08/06). Cada membro confirma o próprio trecho.
+
+## Gabriela Riedel
+
+- a confirmar pela própria
+
+## Luís Renato Freitas de Almeida
+
+- a confirmar pelo próprio
+- Reengenharia de isolamento da persistência na camada de storage (ADR-0010).
+- Consolidação do marco v0.4.0 no `main` (#82).
+
+## Nícolas Arthur Raulino Oliveira
+
+- Redesenho do plugin no estilo git: Source Control View com fetch/pull/push/sync,
+  substituindo os comandos avulsos de sincronização (#79).
+- Reengenharia da camada de sincronização do plugin: consolidação em `core/operations.ts` +
+  `core/status.ts`, extração do helper `recordSynced` e push/pull resilientes a conflito 409 e
+  falha parcial. Decisão e métrica antes/depois em ADR-0011.
+- CD do plugin: workflow que builda e anexa o artefato instalável à release
+  (`.github/workflows/release.yml`).
+- Documentação de instalação do plugin (seção do `DEPLOY.md` e README).
+- Revisões de PRs.
+
+## Nicolas Pitz
+
+- a confirmar pelo próprio
+- Métricas da Sprint 4 nas fichas de `docs/metricas/`.

--- a/docs/contribuicoes-sprint4.md
+++ b/docs/contribuicoes-sprint4.md
@@ -9,9 +9,9 @@ Janela: marco da Sprint 3 (29/05) ao marco da Sprint 4 (08/06). Cada membro conf
 
 ## Luís Renato Freitas de Almeida
 
-- a confirmar pelo próprio
-- Reengenharia de isolamento da persistência na camada de storage (ADR-0010).
+- Reengenharia de isolamento da persistência na camada de storage, com ADR-0010 e testes (#81).
 - Consolidação do marco v0.4.0 no `main` (#82).
+- Revisões de PRs.
 
 ## Nícolas Arthur Raulino Oliveira
 


### PR DESCRIPTION
## O que mudou
- **CD do plugin** (`.github/workflows/release.yml`): ao publicar uma release, builda o plugin e anexa `markupp-plugin-<tag>.zip` + `main.js`/`manifest.json`/`styles.css` à release.
- **ADR-0011** (Source Control View): registra a reengenharia do #79 (5 comandos avulsos → `core/operations.ts` + `core/status.ts` + Source Control View) com **métrica antes/depois**.
- **Contribuições da Sprint 4** (`docs/contribuicoes-sprint4.md`): seção do Nícolas Arthur preenchida; demais como esqueleto a confirmar.
- **README**: seção de instalação do plugin (Obsidian) e link das contribuições da Sprint 4.

## Por quê
- Itens da Entrega 8 (Sprint 4) ligados ao plugin: deploy/distribuição reprodutível do plugin (artefato na release), evidência de reengenharia com métrica antes/depois e registro de contribuição. Entram na `dev` para serem consolidados na release v0.4.0 (#82).

## Como testar
- Plugin: `cd obsidian-plugin && npm ci && npm run build` gera `build/{main.js,manifest.json,styles.css}` (validado localmente; o zip do workflow empacota os 3).
- O workflow `release.yml` dispara em `release: published` e anexa o artefato — verificável ao publicar a v0.4.0 (`gh release view v0.4.0`).
- Ler `docs/adrs/ADR-0011-source-control-view.md` (tabela antes/depois) e `docs/contribuicoes-sprint4.md`.

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)