### PR TITLE
Feature/dockerhub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-image:
+    name: Publica imagem no Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login no Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extrai metadados (tags e labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: riedelgab/ifsces2
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build e push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./markupp
+          file: ./markupp/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/markupp/Dockerfile
+++ b/markupp/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7
+
+FROM golang:1.26-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/markupp ./cmd/markupp
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates \
+  && adduser -D -u 10001 markupp \
+  && mkdir -p /data && chown markupp:markupp /data
+WORKDIR /data
+COPY --from=builder /out/markupp /usr/local/bin/markupp
+USER markupp
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/markupp"]


### PR DESCRIPTION
## O que mudou
  - Adiciona `markupp/Dockerfile` de produção (multi-stage, alpine, ~20MB, non-root).
  - Adiciona `.github/workflows/release.yml` que builda e publica a imagem em `riedelgab/ifsces2` no Docker Hub a cada push de tag `v*` (linux/amd64 e linux/arm64).

  ## Por quê
  - Disponibiliza a imagem do servidor publicamente para a release v0.4.0 da Sprint 4, fortalecendo o item 1 da entrega (ambiente
  reprodutível) e o item 7 (release/tag do marco).

  ## Como testar
  - Após o merge, rodar manualmente o workflow em Actions → Release → Run workflow.
  - Conferir se a imagem aparece em https://hub.docker.com/r/riedelgab/ifsces2.
  - Validar localmente: `docker run -p 8080:8080 riedelgab/ifsces2:latest` e fazer `curl http://localhost:8080/notes`.

  ## Auto-review (checklist)
  - [x] Descrição clara (o que/por quê/como testar)
  - [x] PR pequeno e focado
  - [x] Casos limite considerados (ex.: vazio, 0, erro)
  - [x] Evidência de teste (manual ou automatizado)