### PR TITLE
fix: fixa a versao do golangci-lint no ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: go vet ./...
 
       - name: Run golangci-lint
-        run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run
 
       - name: Run tests
         run: go test ./... -race -count=1


### PR DESCRIPTION
## O que mudou
- Fixa a versao do golangci-lint no CI: troca o `@latest` (caminho v1) por `v2/cmd/golangci-lint@v2.12.2`.

## Por que
- O `@latest` era nao deterministico e divergia do binario usado localmente (v2.12.2). A avaliacao da Entrega 9 apontou falha local do comando por desalinhamento de toolchain. Fixar a versao torna o lint reprodutivel e alinhado entre local e CI.

## Como testar
- Pipeline de CI deste PR: o job "Servidor (Go) tests" deve passar no passo do golangci-lint.

## Auto-review (checklist)
- [x] Descricao clara (o que/por que/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidencia de teste (manual ou automatizado)