### PR TITLE
fix: corrige vulnerabilidades de dependencias do plugin

### DIFF
--- a/obsidian-plugin/package-lock.json
+++ b/obsidian-plugin/package-lock.json
@@ -25,9 +25,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -35,9 +35,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -45,13 +45,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -61,14 +61,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -499,9 +499,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -585,9 +585,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -627,15 +627,15 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.2"
+				"minimatch": "^3.1.5"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -668,20 +668,20 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
 				"espree": "^10.0.1",
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
+				"js-yaml": "^4.1.1",
+				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
@@ -746,25 +746,39 @@
 			}
 		},
 		"node_modules/@humanfs/core": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
 			"engines": {
 				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanfs/node": {
-			"version": "0.16.7",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanfs/core": "^0.19.1",
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
 				"@humanwhocodes/retry": "^0.4.0"
 			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -882,14 +896,14 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.2"
 			},
 			"funding": {
 				"type": "github",
@@ -939,9 +953,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+			"version": "0.133.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -962,9 +976,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+			"integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
 			"cpu": [
 				"arm64"
 			],
@@ -979,9 +993,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -996,9 +1010,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+			"integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
 			"cpu": [
 				"x64"
 			],
@@ -1013,9 +1027,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+			"integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
 			"cpu": [
 				"x64"
 			],
@@ -1030,9 +1044,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+			"integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
 			"cpu": [
 				"arm"
 			],
@@ -1047,9 +1061,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+			"integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1064,9 +1078,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1081,9 +1095,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+			"integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1098,9 +1112,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1115,9 +1129,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+			"integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
 			"cpu": [
 				"x64"
 			],
@@ -1132,9 +1146,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
 			"cpu": [
 				"x64"
 			],
@@ -1149,9 +1163,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+			"integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1166,9 +1180,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+			"integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1185,9 +1199,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+			"integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1202,9 +1216,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+			"integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
 			"cpu": [
 				"x64"
 			],
@@ -1219,9 +1233,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1289,9 +1303,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
@@ -1309,21 +1323,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"version": "20.19.43",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
-		},
-		"node_modules/@types/node/node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/tern": {
 			"version": "0.23.9",
@@ -1524,9 +1531,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1547,19 +1554,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
@@ -1605,14 +1599,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+			"integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.5",
+				"@vitest/utils": "4.1.9",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -1626,8 +1620,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.5",
-				"vitest": "4.1.5"
+				"@vitest/browser": "4.1.9",
+				"vitest": "4.1.9"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -1636,16 +1630,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1654,9 +1648,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1667,13 +1661,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.5",
+				"@vitest/utils": "4.1.9",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1681,14 +1675,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1697,9 +1691,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1707,13 +1701,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
+				"@vitest/pretty-format": "4.1.9",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1722,9 +1716,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1955,9 +1949,9 @@
 			}
 		},
 		"node_modules/ast-v8-to-istanbul": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+			"integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1965,13 +1959,6 @@
 				"estree-walker": "^3.0.3",
 				"js-tokens": "^10.0.0"
 			}
-		},
-		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/async-function": {
 			"version": "1.0.0",
@@ -2007,9 +1994,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2031,15 +2018,15 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -2327,9 +2314,9 @@
 			}
 		},
 		"node_modules/empathic": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
-			"integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+			"integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2337,23 +2324,23 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-			"integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+			"integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.3"
 			},
 			"engines": {
 				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+			"version": "1.24.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+			"integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2419,6 +2406,25 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-abstract-get": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+			"integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.2",
+				"is-callable": "^1.2.7",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/es-define-property": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2440,28 +2446,28 @@
 			}
 		},
 		"node_modules/es-iterator-helpers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-			"integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+			"integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.6",
+				"es-abstract": "^1.24.2",
 				"es-errors": "^1.3.0",
-				"es-set-tostringtag": "^2.0.3",
+				"es-set-tostringtag": "^2.1.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.6",
+				"get-intrinsic": "^1.3.0",
 				"globalthis": "^1.0.4",
 				"gopd": "^1.2.0",
 				"has-property-descriptors": "^1.0.2",
 				"has-proto": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"internal-slot": "^1.1.0",
-				"iterator.prototype": "^1.1.4",
-				"safe-array-concat": "^1.1.3"
+				"iterator.prototype": "^1.1.5",
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2475,9 +2481,9 @@
 			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2517,15 +2523,17 @@
 			}
 		},
 		"node_modules/es-to-primitive": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-			"integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
+			"integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"es-abstract-get": "^1.0.0",
+				"es-errors": "^1.3.0",
 				"is-callable": "^1.2.7",
-				"is-date-object": "^1.0.5",
-				"is-symbol": "^1.0.4"
+				"is-date-object": "^1.1.0",
+				"is-symbol": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2589,25 +2597,25 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
-			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.1",
+				"@eslint/config-array": "^0.21.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.1",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
@@ -2626,7 +2634,7 @@
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -2664,29 +2672,16 @@
 				"eslint": ">=6.0.0"
 			}
 		},
-		"node_modules/eslint-compat-utils/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/eslint-import-resolver-node": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+			"integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^3.2.7",
-				"is-core-module": "^2.13.0",
-				"resolve": "^1.22.4"
+				"is-core-module": "^2.16.1",
+				"resolve": "^2.0.0-next.6"
 			}
 		},
 		"node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -2700,9 +2695,9 @@
 			}
 		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-			"integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+			"integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2737,19 +2732,6 @@
 				"empathic": "^2.0.0",
 				"module-replacements": "^2.8.0",
 				"semver": "^7.6.3"
-			}
-		},
-		"node_modules/eslint-plugin-depend/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-plugin-es-x": {
@@ -2818,6 +2800,16 @@
 				"ms": "^2.1.1"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/eslint-plugin-json-schema-validator": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-5.1.0.tgz",
@@ -2865,9 +2857,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2924,9 +2916,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2960,19 +2952,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/eslint-plugin-n/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd": {
@@ -3047,6 +3026,13 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/eslint-plugin-react": {
 			"version": "7.37.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz",
@@ -3080,22 +3066,14 @@
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
 			}
 		},
-		"node_modules/eslint-plugin-react/node_modules/resolve": {
-			"version": "2.0.0-next.5",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+		"node_modules/eslint-plugin-react/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
+			"license": "ISC",
 			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-plugin-security": {
@@ -3139,9 +3117,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/@eslint/js": {
-			"version": "9.39.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-			"integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3170,9 +3148,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3304,9 +3282,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3419,18 +3397,21 @@
 			}
 		},
 		"node_modules/function.prototype.name": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-			"integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+			"integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
 				"functions-have-names": "^1.2.3",
-				"hasown": "^2.0.2",
-				"is-callable": "^1.2.7"
+				"has-property-descriptors": "^1.0.2",
+				"hasown": "^2.0.4",
+				"is-callable": "^1.2.7",
+				"is-document.all": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3517,9 +3498,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3681,9 +3662,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3837,13 +3818,13 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.2"
+				"hasown": "^2.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3879,6 +3860,22 @@
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-document.all": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+			"integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4226,17 +4223,27 @@
 			}
 		},
 		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -4314,9 +4321,9 @@
 			}
 		},
 		"node_modules/jsonc-eslint-parser": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.1.tgz",
-			"integrity": "sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+			"integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4361,19 +4368,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/jsonc-eslint-parser/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/jsx-ast-utils": {
@@ -4713,6 +4707,13 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/loose-envify/node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4724,13 +4725,13 @@
 			}
 		},
 		"node_modules/magicast": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
+				"@babel/parser": "^7.29.3",
 				"@babel/types": "^7.29.0",
 				"source-map-js": "^1.2.1"
 			}
@@ -4749,19 +4750,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/make-dir/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -4822,9 +4810,9 @@
 			}
 		},
 		"node_modules/module-replacements": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.10.1.tgz",
-			"integrity": "sha512-qkKuLpMHDqRSM676OPL7HUpCiiP3NSxgf8NNR1ga2h/iJLNKTsOSjMEwrcT85DMSti2vmOqxknOVBGWj6H6etQ==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.11.0.tgz",
+			"integrity": "sha512-j5sNQm3VCpQQ7nTqGeOZtoJtV3uKERgCBm9QRhmGRiXiqkf7iRFOkfxdJRZWLkqYY8PNf4cDQF/WfXUYLENrRA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4869,6 +4857,35 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/node-exports-info/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -4994,9 +5011,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.10.3.tgz",
-			"integrity": "sha512-VP+ZSxNMG7y6Z+sU9WqLvJAskCfkFrTz2kFHWmmzis+C+4+ELjk/sazwcTHrHXNZlgCeo8YOlM6SOrAFCynNew==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
@@ -5008,15 +5025,18 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -5164,9 +5184,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -5184,7 +5204,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -5317,13 +5337,16 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.11",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"version": "2.0.0-next.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+			"integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.16.1",
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.2",
+				"node-exports-info": "^1.6.0",
+				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -5379,14 +5402,14 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+			"integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.127.0",
-				"@rolldown/pluginutils": "1.0.0-rc.17"
+				"@oxc-project/types": "=0.133.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -5395,21 +5418,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+				"@rolldown/binding-android-arm64": "1.0.3",
+				"@rolldown/binding-darwin-arm64": "1.0.3",
+				"@rolldown/binding-darwin-x64": "1.0.3",
+				"@rolldown/binding-freebsd-x64": "1.0.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.3",
+				"@rolldown/binding-linux-arm64-musl": "1.0.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-musl": "1.0.3",
+				"@rolldown/binding-openharmony-arm64": "1.0.3",
+				"@rolldown/binding-wasm32-wasi": "1.0.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.3",
+				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -5437,15 +5460,15 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+			"integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"get-intrinsic": "^1.2.6",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
+				"get-intrinsic": "^1.3.0",
 				"has-symbols": "^1.1.0",
 				"isarray": "^2.0.5"
 			},
@@ -5523,13 +5546,16 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -5605,15 +5631,15 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},
@@ -5625,14 +5651,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5765,19 +5791,20 @@
 			}
 		},
 		"node_modules/string.prototype.trim": {
-			"version": "1.2.10",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-			"integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+			"integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
 				"define-data-property": "^1.1.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-object-atoms": "^1.0.0",
-				"has-property-descriptors": "^1.0.2"
+				"es-abstract": "^1.24.2",
+				"es-object-atoms": "^1.1.2",
+				"has-property-descriptors": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5787,16 +5814,16 @@
 			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-			"integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+			"integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0"
+				"es-object-atoms": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5904,9 +5931,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tapable": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5925,9 +5952,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5935,9 +5962,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6035,9 +6062,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6151,18 +6178,18 @@
 			}
 		},
 		"node_modules/typed-array-length": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-			"integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+			"integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"is-typed-array": "^1.1.13",
-				"possible-typed-array-names": "^1.0.0",
-				"reflect.getprototypeof": "^1.0.6"
+				"call-bind": "^1.0.9",
+				"for-each": "^0.3.5",
+				"gopd": "^1.2.0",
+				"is-typed-array": "^1.1.15",
+				"possible-typed-array-names": "^1.1.0",
+				"reflect.getprototypeof": "^1.0.10"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6228,9 +6255,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -6245,19 +6272,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.5",
-				"@vitest/mocker": "4.1.5",
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/runner": "4.1.5",
-				"@vitest/snapshot": "4.1.5",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/expect": "4.1.9",
+				"@vitest/mocker": "4.1.9",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/runner": "4.1.9",
+				"@vitest/snapshot": "4.1.9",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -6285,12 +6312,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.5",
-				"@vitest/browser-preview": "4.1.5",
-				"@vitest/browser-webdriverio": "4.1.5",
-				"@vitest/coverage-istanbul": "4.1.5",
-				"@vitest/coverage-v8": "4.1.5",
-				"@vitest/ui": "4.1.5",
+				"@vitest/browser-playwright": "4.1.9",
+				"@vitest/browser-preview": "4.1.9",
+				"@vitest/browser-webdriverio": "4.1.9",
+				"@vitest/coverage-istanbul": "4.1.9",
+				"@vitest/coverage-v8": "4.1.9",
+				"@vitest/ui": "4.1.9",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6335,9 +6362,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -6353,9 +6380,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/android-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -6371,9 +6398,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6389,9 +6416,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/android-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -6407,9 +6434,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -6425,9 +6452,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -6443,9 +6470,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6461,9 +6488,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -6479,9 +6506,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -6497,9 +6524,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -6515,9 +6542,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -6533,9 +6560,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -6551,9 +6578,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -6569,9 +6596,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -6587,9 +6614,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -6605,9 +6632,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -6623,9 +6650,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -6641,9 +6668,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6659,9 +6686,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -6677,9 +6704,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -6695,9 +6722,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -6713,9 +6740,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -6731,9 +6758,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -6749,9 +6776,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -6767,9 +6794,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -6785,13 +6812,13 @@
 			}
 		},
 		"node_modules/vitest/node_modules/@vitest/mocker": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.5",
+				"@vitest/spy": "4.1.9",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -6812,9 +6839,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/esbuild": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6827,32 +6854,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.0",
-				"@esbuild/android-arm": "0.28.0",
-				"@esbuild/android-arm64": "0.28.0",
-				"@esbuild/android-x64": "0.28.0",
-				"@esbuild/darwin-arm64": "0.28.0",
-				"@esbuild/darwin-x64": "0.28.0",
-				"@esbuild/freebsd-arm64": "0.28.0",
-				"@esbuild/freebsd-x64": "0.28.0",
-				"@esbuild/linux-arm": "0.28.0",
-				"@esbuild/linux-arm64": "0.28.0",
-				"@esbuild/linux-ia32": "0.28.0",
-				"@esbuild/linux-loong64": "0.28.0",
-				"@esbuild/linux-mips64el": "0.28.0",
-				"@esbuild/linux-ppc64": "0.28.0",
-				"@esbuild/linux-riscv64": "0.28.0",
-				"@esbuild/linux-s390x": "0.28.0",
-				"@esbuild/linux-x64": "0.28.0",
-				"@esbuild/netbsd-arm64": "0.28.0",
-				"@esbuild/netbsd-x64": "0.28.0",
-				"@esbuild/openbsd-arm64": "0.28.0",
-				"@esbuild/openbsd-x64": "0.28.0",
-				"@esbuild/openharmony-arm64": "0.28.0",
-				"@esbuild/sunos-x64": "0.28.0",
-				"@esbuild/win32-arm64": "0.28.0",
-				"@esbuild/win32-ia32": "0.28.0",
-				"@esbuild/win32-x64": "0.28.0"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/vitest/node_modules/picomatch": {
@@ -6869,17 +6896,17 @@
 			}
 		},
 		"node_modules/vitest/node_modules/vite": {
-			"version": "8.0.10",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+			"version": "8.0.16",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.10",
-				"rolldown": "1.0.0-rc.17",
-				"tinyglobby": "^0.2.16"
+				"postcss": "^8.5.15",
+				"rolldown": "1.0.3",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -6895,7 +6922,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
+				"@vitejs/devtools": "^0.1.18",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -7037,14 +7064,14 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.22",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
+				"call-bind": "^1.0.9",
 				"call-bound": "^1.0.4",
 				"for-each": "^0.3.5",
 				"get-proto": "^1.0.1",
@@ -7086,9 +7113,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7102,9 +7129,9 @@
 			}
 		},
 		"node_modules/yaml-eslint-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.0.tgz",
-			"integrity": "sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
+			"integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## O que mudou
- Roda `npm audit fix` no plugin, atualizando apenas o `package-lock.json`. Resolve as 3 vulnerabilidades reportadas (1 high em `vite`, 1 moderate em `js-yaml`, 1 low em `esbuild`), todas transitivas via `vitest` (dependencia de teste).

## Por que
- A avaliacao da Entrega 9 apontou 1 vulnerabilidade high a ser acompanhada. O `npm audit` agora reporta 0 vulnerabilidades. Como o `package.json` nao mudou, nao ha bump de dependencia direta.

## Como testar
- `cd obsidian-plugin && npm ci && npm audit` deve reportar 0 vulnerabilidades.
- `npm run lint`, `npm run build` e `npm test` continuam verdes (55 testes).

## Auto-review (checklist)
- [x] Descricao clara (o que/por que/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidencia de teste (manual ou automatizado)