### PR TITLE
docs: revisao final da documentacao para o release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Excesso de informação descentralizada e dados desestruturados sem métodos de 
 - Expor uma API REST que permita integração com clientes
 - Processar documentos automaticamente para busca semântica
 
+## MVP entregue (Release Candidate)
+
+As seções acima são a visão do produto. O MVP entregue cobre CRUD de notas via
+plugin e API REST, listagem, busca por substring e sincronização com detecção de
+conflito e sobrescrita forçada.
+
+Fora do MVP: versionamento, organização hierárquica, busca semântica e
+autenticação. Ver [requisitos do MVP](docs/requisitos-mvp.md) e
+[limitações conhecidas](docs/limitacoes-conhecidas.md).
+
 ## Instalação do plugin (Obsidian)
 1. Baixe o artefato da release `v0.4.0`: `markupp-plugin-v0.4.0.zip` (ou os arquivos `main.js`, `manifest.json` e `styles.css` anexados à release).
 2. Crie a pasta `<seu-vault>/.obsidian/plugins/obsidian-markupp-plugin/` e coloque os três arquivos nela (extraia o zip aqui).
@@ -54,6 +64,7 @@ Excesso de informação descentralizada e dados desestruturados sem métodos de 
 
 ## Critérios de Qualidade
 - [Critérios de Qualidade](docs/qualidade.md)
+- [Testes de Aceitação](docs/testes-aceitacao.md)
 
 ## Riscos
 - [Tabelas de Riscos](docs/riscos.md)

--- a/docs/limitacoes-conhecidas.md
+++ b/docs/limitacoes-conhecidas.md
@@ -1,0 +1,13 @@
+# Limitações Conhecidas (Release Candidate)
+
+- Sem versionamento/histórico: a sincronização detecta conflito (`409`) e
+  sobrescreve, mas não guarda versões
+- Sem autenticação: uso local/self-hosted (ADR-0005), não exponha fora de
+  `localhost`
+- Sem organização hierárquica: notas por `path`, sem árvore de pastas
+- Sem busca semântica: busca por substring no `path`
+- Validação ponta a ponta no Obsidian é manual ([testes de aceitação](testes-aceitacao.md));
+  a lógica do plugin é testada
+- Imagem Docker: prefira tag versionada à `latest` ([DEPLOY](DEPLOY.md))
+
+Itens fora do escopo do MVP: [requisitos do MVP](requisitos-mvp.md).

--- a/docs/riscos.md
+++ b/docs/riscos.md
@@ -109,3 +109,16 @@ Ações contínuas para reduzir a probabilidade ou o impacto antes que o risco s
   - Presença e atividade dos membros no board: sinaliza REQ-1.
   - Falhas em builds/integração: sinaliza RTE-1.
 - **Escalonamento**: riscos que migrem para a faixa Alta/Alta na matriz passam a ser discutidos em toda reunião semanal, até retornarem a um patamar aceitável.
+
+## 4 Fechamento dos riscos (Release Candidate)
+
+Status de cada risco ao fim do MVP.
+
+| ID | Status | Observação |
+| --- | --- | --- |
+| RES-1 | Materializado, mitigado | Complexidade da interface reduzida pela migração de interface web para plugin do Obsidian (ADR-0004) |
+| RPR-1 | Materializado | Backlog x horas gerou atrasos e a recuperação da Entrega 7; mitigado com sprints temáticas |
+| REQ-1 | Não ocorreu | - |
+| REQ-2 | Não ocorreu | - |
+| RTE-1 | Não ocorreu | - |
+| RQP-1 | Não ocorreu | - |


### PR DESCRIPTION
## O que mudou
- `riscos.md`: adiciona secao de acompanhamento e fechamento dos riscos no RC (status final de cada risco).
- `limitacoes-conhecidas.md`: novo documento com as limitacoes conhecidas do MVP no RC.
- `README.md`: esclarece o escopo do MVP entregue (separa visao do produto do que foi entregue, corrige a promessa de "controle de versoes") e adiciona links para testes de aceitacao e limitacoes.

## Por que
- A avaliacao da Entrega 9 apontou: documentacao ainda como fechamento da Sprint 4 e nao do RC; `riscos.md` sem acompanhamento/fechamento final; README prometendo "controle de versoes" sem indicacao clara do MVP entregue; e ausencia de documento de limitacoes conhecidas.

## Como testar
- Ler os tres arquivos; conferir os links relativos no README.

## Auto-review (checklist)
- [x] Descricao clara (o que/por que/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidencia de teste (manual ou automatizado)