### PR TITLE
chore: preparacao do release (readme generico e versao do plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ autenticação. Ver [requisitos do MVP](docs/requisitos-mvp.md) e
 [limitações conhecidas](docs/limitacoes-conhecidas.md).
 
 ## Instalação do plugin (Obsidian)
-1. Baixe o artefato da release `v0.4.0`: `markupp-plugin-v0.4.0.zip` (ou os arquivos `main.js`, `manifest.json` e `styles.css` anexados à release).
+1. Baixe o artefato (`markupp-plugin-<versão>.zip`, ou os arquivos `main.js`, `manifest.json` e `styles.css`) da [release mais recente](https://github.com/IFSC-ES2/projeto-markupp/releases/latest).
 2. Crie a pasta `<seu-vault>/.obsidian/plugins/obsidian-markupp-plugin/` e coloque os três arquivos nela (extraia o zip aqui).
 3. No Obsidian: **Configurações → Plugins da comunidade**, ative o **Markupp**.
 4. Nas opções do plugin, ajuste o **`serverUrl`** (padrão `http://localhost:8080`) para o endereço do servidor Markupp.

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-markupp-plugin",
 	"name": "Markupp",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"minAppVersion": "0.15.0",
 	"description": "Self-hosted markdown rendering plugin for Obsidian.",
 	"author": "Luis Renato, Nicolas Arthur, Nicolas Pitz, Gabriela Riedel",

--- a/obsidian-plugin/package-lock.json
+++ b/obsidian-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-markupp-plugin",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-markupp-plugin",
-			"version": "0.1.0",
+			"version": "1.0.0",
 			"dependencies": {
 				"obsidian": "latest"
 			},

--- a/obsidian-plugin/package.json
+++ b/obsidian-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-markupp-plugin",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "Plugin Obsidian do projeto Markupp: envia notas para o servidor Markupp self-hosted.",
 	"main": "main.js",
 	"type": "module",


### PR DESCRIPTION
## O que mudou
- README: link do plugin passa a apontar para a release mais recente (`releases/latest`), sem versao fixa, para nao precisar atualizar a cada release.
- Plugin: versao interna (manifest.json + package.json) sobe de 0.1.0 para 1.0.0 (versions.json ja tinha 1.0.0).

## Por que
- Evitar manutencao manual recorrente da documentacao por release (tag fixa no README envelhece). 

## Como testar
- README: o link aponta para `releases/latest`.
- Plugin: `cd obsidian-plugin && npm ci && npm run build && npm test` continuam verdes (55 testes); manifest e package em 1.0.0.

## Auto-review (checklist)
- [x] Descricao clara (o que/por que/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidencia de teste (manual ou automatizado)